### PR TITLE
Default content type is changed

### DIFF
--- a/src/main/java/nl/dtls/fairdatapoint/api/config/RestApiContext.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/config/RestApiContext.java
@@ -22,6 +22,8 @@
  */
 package nl.dtls.fairdatapoint.api.config;
 
+
+import static org.eclipse.rdf4j.rio.RDFFormat.TURTLE;
 import java.io.IOException;
 import java.util.List;
 
@@ -62,7 +64,6 @@ import nl.dtls.fairdatapoint.repository.impl.StoreManagerImpl;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import static org.eclipse.rdf4j.rio.RDFFormat.TURTLE;
 import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
@@ -86,14 +87,14 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
 
     @Autowired
     private List<AbstractMetadataMessageConverter<?>> metadataConverters;
-    
+
     private final ValueFactory valueFactory = SimpleValueFactory.getInstance();
-    
+
     @Override
     public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
         converters.addAll(metadataConverters);
     }
-    
+
     @Override
     public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
         configurer.defaultContentType(MediaType.parseMediaType(TURTLE.getDefaultMIMEType()));
@@ -101,65 +102,59 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
             converter.configureContentNegotiation(configurer);
         }
     }
-    
+
     @Bean(name = "publisher")
-    public Agent publisher(@Value("${metadataProperties.publisherURI:nil}") 
-            String publisherURI, 
-            @Value("${metadataProperties.publisherName:nil}") 
-                    String publishername) {
+    public Agent publisher(@Value("${metadataProperties.publisherURI:nil}") String publisherURI,
+            @Value("${metadataProperties.publisherName:nil}") String publishername) {
         Agent publisher = null;
-        if (!publisherURI.contentEquals("nil") && 
-                !publishername.contentEquals("nil")) {
+        if (!publisherURI.contentEquals("nil")
+                && !publishername.contentEquals("nil")) {
             publisher = new Agent();
             publisher.setUri(valueFactory.createIRI(publisherURI));
-            publisher.setName(valueFactory.createLiteral(publishername));            
+            publisher.setName(valueFactory.createLiteral(publishername));
         }
         return publisher;
-    } 
-    
+    }
+
     @Bean(name = "language")
-    public IRI language(@Value("${metadataProperties.language:nil}") 
-            String languageURI) {
+    public IRI language(@Value("${metadataProperties.language:nil}") String languageURI) {
         IRI language = null;
         if (!languageURI.contentEquals("nil")) {
-            language = valueFactory.createIRI(languageURI);           
+            language = valueFactory.createIRI(languageURI);
         }
         return language;
     }
-    
+
     @Bean(name = "license")
-    public IRI license(@Value("${metadataProperties.license:nil}") 
-            String licenseURI) {
+    public IRI license(@Value("${metadataProperties.license:nil}") String licenseURI) {
         IRI license = null;
         if (!licenseURI.contentEquals("nil")) {
-            license = valueFactory.createIRI(licenseURI);           
+            license = valueFactory.createIRI(licenseURI);
         }
         return license;
     }
-    
 
     @Bean(name = "repository", initMethod = "initialize",
             destroyMethod = "shutDown")
     public Repository repository(@Value("${store.type:1}") int storeType,
-            @Value("${store.url}") String storeUrl, 
+            @Value("${store.url}") String storeUrl,
             @Value("${store.username:nil}") String storeUsername,
             @Value("${store.password:nil}") String storeUserPassword,
             @Value("${store.dir:}") String storeDir)
             throws RepositoryException {
         Repository repository;
-        if (storeType == 1 && !storeUsername.isEmpty() && 
-                !storeUsername.contains("nil")) { // HTTP endpoint
+        if (storeType == 1 && !storeUsername.isEmpty()
+                && !storeUsername.contains("nil")) { // HTTP endpoint
             SPARQLRepository sRepository = new SPARQLRepository(storeUrl);
             LOGGER.info("Initializing HTTP triple store ");
-            sRepository.setUsernameAndPassword(storeUsername, 
-                    storeUserPassword); 
+            sRepository.setUsernameAndPassword(storeUsername,
+                    storeUserPassword);
             return sRepository;
-        } else if (storeType == 2 && !storeDir.isEmpty()){
+        } else if (storeType == 2 && !storeDir.isEmpty()) {
             File dataDir = new File(storeDir);
             LOGGER.info("Initializing native store");
             repository = new SailRepository(new NativeStore(dataDir));
-        }
-        else { // In memory is the default store
+        } else { // In memory is the default store
             Sail store = new MemoryStore();
             repository = new SailRepository(store);
             LOGGER.info("Initializing inmemory store");
@@ -173,6 +168,7 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
             StoreManagerException {
         return new StoreManagerImpl();
     }
+
     @Override
     public void addResourceHandlers(final ResourceHandlerRegistry registry) {
         registry.setOrder(Integer.MIN_VALUE + 1).
@@ -189,16 +185,16 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
             final DefaultServletHandlerConfigurer configurer) {
         configurer.enable();
     }
-    
+
     @Override
     public void configureViewResolvers(ViewResolverRegistry registry) {
         registry.viewResolver(handlebars());
     }
-    
+
     @Bean
     public ViewResolver handlebars() {
         HandlebarsViewResolver viewResolver = new HandlebarsViewResolver();
-        
+
         // add handlebars helper to get a label's literal without datatype
         viewResolver.registerHelper("literal", new Helper<Literal>() {
             @Override
@@ -206,11 +202,11 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
                 return literal.getLabel();
             }
         });
-        
+
         viewResolver.setPrefix("/WEB-INF/templates/");
         viewResolver.setSuffix(".hbs");
         viewResolver.setFailOnMissingFile(false);
-        
+
         return viewResolver;
     }
 }

--- a/src/main/java/nl/dtls/fairdatapoint/api/config/RestApiContext.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/config/RestApiContext.java
@@ -62,8 +62,10 @@ import nl.dtls.fairdatapoint.repository.impl.StoreManagerImpl;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import static org.eclipse.rdf4j.rio.RDFFormat.TURTLE;
 import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 
 /**
  * Spring context file.
@@ -94,6 +96,7 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
     
     @Override
     public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
+        configurer.defaultContentType(MediaType.parseMediaType(TURTLE.getDefaultMIMEType()));
         for (AbstractMetadataMessageConverter<?> converter : metadataConverters) {
             converter.configureContentNegotiation(configurer);
         }

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/MetadataController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/MetadataController.java
@@ -86,7 +86,7 @@ import springfox.documentation.annotations.ApiIgnore;
 @RequestMapping("${urlPath.root:/fdp}")
 public class MetadataController {
 
-    private final static Logger LOGGER = LogManager.getLogger(MetadataController.class);
+    private static final Logger LOGGER = LogManager.getLogger(MetadataController.class);
     @Autowired
     private FairMetaDataService fairMetaDataService;
     private final ValueFactory valueFactory = SimpleValueFactory.getInstance();

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/MetadataController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/MetadataController.java
@@ -495,8 +495,11 @@ public class MetadataController {
             url = url.substring(0, url.length() - 1);
         }
         
-        List<String> rdfExt = RDFWriterRegistry.getInstance().getKeys().stream()
-                .map(RDFFormat::getDefaultFileExtension).collect(Collectors.toList());
+        List<String> rdfExt = RDFWriterRegistry.getInstance()
+                .getKeys()
+                .stream()
+                .map(RDFFormat::getDefaultFileExtension)
+                .collect(Collectors.toList());
 
         for (String ext : rdfExt) {
             String extension = "." + ext;

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/MetadataController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/MetadataController.java
@@ -104,8 +104,7 @@ public class MetadataController {
      * @throws nl.dtl.fairmetadata4j.io.MetadataException
      */
     @ApiOperation(value = "FDP metadata")
-    @RequestMapping(method = RequestMethod.GET, produces = {"text/turtle", "application/ld+json",
-        "application/rdf+xml", "text/n3"})
+    @RequestMapping(method = RequestMethod.GET)
     @ResponseStatus(HttpStatus.OK)
     public FDPMetadata getFDPMetaData(final HttpServletRequest request, 
             HttpServletResponse response) throws FairMetadataServiceException, 

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/MetadataController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/MetadataController.java
@@ -38,7 +38,6 @@ import org.apache.logging.log4j.Logger;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
@@ -60,7 +59,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import nl.dtl.fairmetadata4j.io.MetadataException;
 import nl.dtl.fairmetadata4j.io.MetadataParserException;
-import nl.dtl.fairmetadata4j.model.Agent;
 import nl.dtl.fairmetadata4j.model.CatalogMetadata;
 import nl.dtl.fairmetadata4j.model.DataRecordMetadata;
 import nl.dtl.fairmetadata4j.model.DatasetMetadata;
@@ -88,43 +86,39 @@ import springfox.documentation.annotations.ApiIgnore;
 @RequestMapping("${urlPath.root:/fdp}")
 public class MetadataController {
 
-    private final static Logger LOGGER
-            = LogManager.getLogger(MetadataController.class);
+    private final static Logger LOGGER = LogManager.getLogger(MetadataController.class);
     @Autowired
     private FairMetaDataService fairMetaDataService;
     private final ValueFactory valueFactory = SimpleValueFactory.getInstance();
 
     /**
-     * To handle GET FDP metadata request. (Note:) The first value in the
-     * produces annotation is used as a fallback value, for the request with the
-     * accept header value (* / *), manually setting the contentType of the
-     * response is not working.
+     * To handle GET FDP metadata request. (Note:) The first value in the produces annotation is
+     * used as a fallback value, for the request with the accept header value (* / *), manually
+     * setting the contentType of the response is not working.
      *
      * @param request Http request
      * @param response Http response
-     * @return Metadata about the FDP in one of the acceptable formats (RDF
-     * Turtle, JSON-LD, RDF XML and RDF N3)
+     * @return Metadata about the FDP in one of the acceptable formats (RDF Turtle, JSON-LD, RDF XML
+     * and RDF N3)
      * @throws nl.dtls.fairdatapoint.service.FairMetadataServiceException
      * @throws nl.dtl.fairmetadata4j.io.MetadataException
      */
     @ApiOperation(value = "FDP metadata")
-    @RequestMapping(method = RequestMethod.GET,
-            produces = {"text/turtle",
-                "application/ld+json", "application/rdf+xml", "text/n3"}
-    )
+    @RequestMapping(method = RequestMethod.GET, produces = {"text/turtle", "application/ld+json",
+        "application/rdf+xml", "text/n3"})
     @ResponseStatus(HttpStatus.OK)
-    public FDPMetadata getFDPMetaData(final HttpServletRequest request,
-            HttpServletResponse response) throws FairMetadataServiceException,
-            ResourceNotFoundException,
-            MetadataException {
+    public FDPMetadata getFDPMetaData(final HttpServletRequest request, 
+            HttpServletResponse response) throws FairMetadataServiceException, 
+            ResourceNotFoundException, MetadataException {
         LOGGER.info("Request to get FDP metadata");
         LOGGER.info("GET : " + request.getRequestURL());
         String uri = getRequesedURL(request);
+        
         if (!isFDPMetaDataAvailable(uri)) {
             storeDefaultFDPMetadata(uri);
         }
-        FDPMetadata metadata = fairMetaDataService.retrieveFDPMetaData(
-                valueFactory.createIRI(uri));
+        
+        FDPMetadata metadata = fairMetaDataService.retrieveFDPMetaData(valueFactory.createIRI(uri));
         LoggerUtils.logRequest(LOGGER, request, response);
         return metadata;
     }
@@ -132,39 +126,35 @@ public class MetadataController {
     private boolean isFDPMetaDataAvailable(String uri) {
         FDPMetadata metadata;
         try {
-            metadata = fairMetaDataService.retrieveFDPMetaData(
-                    valueFactory.createIRI(uri));
+            metadata = fairMetaDataService.retrieveFDPMetaData(valueFactory.createIRI(uri));
             if (metadata.getUri() == null) {
                 return false;
             }
         } catch (ResourceNotFoundException ex) {
             return false;
-        }catch (FairMetadataServiceException ex) {
-            LOGGER.error("Error retrieving FDP metadata. Msg:" + 
-                    ex.getMessage());
-
-        } 
+        } catch (FairMetadataServiceException ex) {
+            LOGGER.error("Error retrieving FDP metadata. Msg:" + ex.getMessage());
+        }
         return true;
     }
 
     @ApiIgnore
-    @RequestMapping(method = RequestMethod.GET,
-            produces = MediaType.TEXT_HTML_VALUE)
+    @RequestMapping(method = RequestMethod.GET, produces = MediaType.TEXT_HTML_VALUE)
     public ModelAndView getHtmlFdpMetadata(HttpServletRequest request) throws
-            FairMetadataServiceException, ResourceNotFoundException,
-            MetadataException {
+            FairMetadataServiceException, ResourceNotFoundException, MetadataException {
         ModelAndView mav = new ModelAndView("repository");
         LOGGER.info("Request to get FDP metadata");
         LOGGER.info("GET : " + request.getRequestURL());
         String uri = getRequesedURL(request);
+        
         if (!isFDPMetaDataAvailable(uri)) {
             storeDefaultFDPMetadata(uri);
         }
-        FDPMetadata metadata = fairMetaDataService.retrieveFDPMetaData(
-                valueFactory.createIRI(uri));
+        
+        FDPMetadata metadata = fairMetaDataService.retrieveFDPMetaData(valueFactory.createIRI(uri));
         mav.addObject("metadata", metadata);
-        mav.addObject("jsonLd", MetadataUtils.getString(metadata,
-                RDFFormat.JSONLD, MetadataUtils.SCHEMA_DOT_ORG_MODEL));
+        mav.addObject("jsonLd", MetadataUtils.getString(metadata, RDFFormat.JSONLD,
+                MetadataUtils.SCHEMA_DOT_ORG_MODEL));
         return mav;
     }
 
@@ -174,27 +164,24 @@ public class MetadataController {
      * @param id
      * @param request
      * @param response
-     * @return Metadata about the catalog in one of the acceptable formats (RDF
-     * Turtle, JSON-LD, RDF XML and RDF N3)
+     * @return Metadata about the catalog in one of the acceptable formats (RDF Turtle, JSON-LD, RDF
+     * XML and RDF N3)
      *
      * @throws IllegalStateException
      * @throws FairMetadataServiceException
      */
     @ApiOperation(value = "Catalog metadata")
-    @RequestMapping(value = "/catalog/{id}", method = RequestMethod.GET,
-            produces = {"text/turtle",
-                "application/ld+json", "application/rdf+xml", "text/n3"}
-    )
+    @RequestMapping(value = "/catalog/{id}", method = RequestMethod.GET, produces = {"text/turtle",
+        "application/ld+json", "application/rdf+xml", "text/n3"})
     @ResponseStatus(HttpStatus.OK)
-    public CatalogMetadata getCatalogMetaData(
-            @PathVariable final String id, HttpServletRequest request,
-            HttpServletResponse response) throws FairMetadataServiceException,
-            ResourceNotFoundException {
+    public CatalogMetadata getCatalogMetaData(@PathVariable final String id, 
+            HttpServletRequest request, HttpServletResponse response) throws 
+            FairMetadataServiceException, ResourceNotFoundException {
         LOGGER.info("Request to get CATALOG metadata with ID ", id);
         LOGGER.info("GET : " + request.getRequestURL());
         String uri = getRequesedURL(request);
-        CatalogMetadata metadata = fairMetaDataService.
-                retrieveCatalogMetaData(valueFactory.createIRI(uri));
+        CatalogMetadata metadata = fairMetaDataService.retrieveCatalogMetaData(
+                valueFactory.createIRI(uri));
         LoggerUtils.logRequest(LOGGER, request, response);
         return metadata;
     }
@@ -203,15 +190,14 @@ public class MetadataController {
     @RequestMapping(value = "/catalog/{id}", method = RequestMethod.GET,
             produces = MediaType.TEXT_HTML_VALUE)
     public ModelAndView getHtmlCatalogMetadata(HttpServletRequest request)
-            throws FairMetadataServiceException, ResourceNotFoundException,
-            MetadataException {
+            throws FairMetadataServiceException, ResourceNotFoundException, MetadataException {
         ModelAndView mav = new ModelAndView("catalog");
         String uri = getRequesedURL(request);
-        CatalogMetadata metadata = fairMetaDataService.
-                retrieveCatalogMetaData(valueFactory.createIRI(uri));
+        CatalogMetadata metadata = fairMetaDataService.retrieveCatalogMetaData(
+                valueFactory.createIRI(uri));
         mav.addObject("metadata", metadata);
-        mav.addObject("jsonLd", MetadataUtils.getString(metadata,
-                RDFFormat.JSONLD, MetadataUtils.SCHEMA_DOT_ORG_MODEL));
+        mav.addObject("jsonLd", MetadataUtils.getString(metadata, RDFFormat.JSONLD,
+                MetadataUtils.SCHEMA_DOT_ORG_MODEL));
         return mav;
     }
 
@@ -221,27 +207,23 @@ public class MetadataController {
      * @param id
      * @param request
      * @param response
-     * @return Metadata about the dataset in one of the acceptable formats (RDF
-     * Turtle, JSON-LD, RDF XML and RDF N3)
+     * @return Metadata about the dataset in one of the acceptable formats (RDF Turtle, JSON-LD, RDF
+     * XML and RDF N3)
      *
      * @throws FairMetadataServiceException
      */
     @ApiOperation(value = "Dataset metadata")
-    @RequestMapping(value = "/dataset/{id}",
-            method = RequestMethod.GET,
-            produces = {"text/turtle",
-                "application/ld+json", "application/rdf+xml", "text/n3"}
-    )
+    @RequestMapping(value = "/dataset/{id}", method = RequestMethod.GET, produces = {"text/turtle",
+                "application/ld+json", "application/rdf+xml", "text/n3"})
     @ResponseStatus(HttpStatus.OK)
-    public DatasetMetadata getDatasetMetaData(
-            @PathVariable final String id, HttpServletRequest request,
-            HttpServletResponse response) throws FairMetadataServiceException,
-            ResourceNotFoundException {
+    public DatasetMetadata getDatasetMetaData(@PathVariable final String id,
+            HttpServletRequest request, HttpServletResponse response) throws 
+            FairMetadataServiceException, ResourceNotFoundException {
         LOGGER.info("Request to get DATASET metadata with ID ", id);
         LOGGER.info("GET : " + request.getRequestURL());
         String uri = getRequesedURL(request);
-        DatasetMetadata metadata = fairMetaDataService.
-                retrieveDatasetMetaData(valueFactory.createIRI(uri));
+        DatasetMetadata metadata = fairMetaDataService.retrieveDatasetMetaData(
+                valueFactory.createIRI(uri));
         LoggerUtils.logRequest(LOGGER, request, response);
         return metadata;
     }
@@ -250,66 +232,57 @@ public class MetadataController {
     @RequestMapping(value = "/dataset/{id}", method = RequestMethod.GET,
             produces = MediaType.TEXT_HTML_VALUE)
     public ModelAndView getHtmlDatsetMetadata(HttpServletRequest request)
-            throws FairMetadataServiceException, ResourceNotFoundException,
-            MetadataException {
+            throws FairMetadataServiceException, ResourceNotFoundException, MetadataException {
         ModelAndView mav = new ModelAndView("dataset");
         String uri = getRequesedURL(request);
-        DatasetMetadata metadata = fairMetaDataService.
-                retrieveDatasetMetaData(valueFactory.createIRI(uri));
+        DatasetMetadata metadata = fairMetaDataService.retrieveDatasetMetaData(
+                valueFactory.createIRI(uri));
         mav.addObject("metadata", metadata);
-        mav.addObject("jsonLd", MetadataUtils.getString(metadata,
-                RDFFormat.JSONLD, MetadataUtils.SCHEMA_DOT_ORG_MODEL));
+        mav.addObject("jsonLd", MetadataUtils.getString(metadata, RDFFormat.JSONLD, 
+                MetadataUtils.SCHEMA_DOT_ORG_MODEL));
         return mav;
     }
-    
-    
+
     /**
      * Get datarecord metadata
      *
      * @param id
      * @param request
      * @param response
-     * @return Metadata about the dataset in one of the acceptable formats (RDF
-     * Turtle, JSON-LD, RDF XML and RDF N3)
+     * @return Metadata about the dataset in one of the acceptable formats (RDF Turtle, JSON-LD, RDF
+     * XML and RDF N3)
      *
      * @throws FairMetadataServiceException
      */
     @ApiOperation(value = "Dataset metadata")
-    @RequestMapping(value = "/datarecord/{id}",
-            method = RequestMethod.GET,
-            produces = {"text/turtle",
-                "application/ld+json", "application/rdf+xml", "text/n3"}
-    )
+    @RequestMapping(value = "/datarecord/{id}", method = RequestMethod.GET,
+            produces = {"text/turtle", "application/ld+json", "application/rdf+xml", "text/n3"})
     @ResponseStatus(HttpStatus.OK)
-    public DataRecordMetadata getDataRecordMetaData(
-            @PathVariable final String id, HttpServletRequest request,
-            HttpServletResponse response) throws FairMetadataServiceException,
-            ResourceNotFoundException {	
-    		
+    public DataRecordMetadata getDataRecordMetaData(@PathVariable final String id,
+            HttpServletRequest request, HttpServletResponse response) throws
+            FairMetadataServiceException, ResourceNotFoundException {
         LOGGER.info("Request to get DATARECORD metadata with ID ", id);
-	LOGGER.info("GET : " + request.getRequestURL());
-	String uri = getRequesedURL(request);
-	DataRecordMetadata metadata = fairMetaDataService.
-                retrieveDataRecordMetadata(valueFactory.createIRI(uri));
-        LoggerUtils.logRequest(LOGGER, request, response); 
+        LOGGER.info("GET : " + request.getRequestURL());
+        String uri = getRequesedURL(request);
+        DataRecordMetadata metadata = fairMetaDataService.retrieveDataRecordMetadata(
+                valueFactory.createIRI(uri));
+        LoggerUtils.logRequest(LOGGER, request, response);
         return metadata;
     }
 
     @ApiIgnore
     @RequestMapping(value = "/datarecord/{id}", method = RequestMethod.GET,
             produces = MediaType.TEXT_HTML_VALUE)
-    public ModelAndView getHtmlDataRecordMetadata(HttpServletRequest request)
-            throws FairMetadataServiceException, ResourceNotFoundException,
-            MetadataException { 
-        ModelAndView mav = new ModelAndView("dataset");	        
-        String uri = getRequesedURL(request);	        
-        DataRecordMetadata metadata = fairMetaDataService.	                
-                retrieveDataRecordMetadata(valueFactory.createIRI(uri));	        
-        mav.addObject("metadata", metadata);	        
-        mav.addObject("jsonLd", MetadataUtils.getString(metadata, 
-                RDFFormat.JSONLD));	        
+    public ModelAndView getHtmlDataRecordMetadata(HttpServletRequest request) throws
+            FairMetadataServiceException, ResourceNotFoundException, MetadataException {
+        ModelAndView mav = new ModelAndView("dataset");
+        String uri = getRequesedURL(request);
+        DataRecordMetadata metadata = fairMetaDataService.retrieveDataRecordMetadata(
+                valueFactory.createIRI(uri));
+        mav.addObject("metadata", metadata);
+        mav.addObject("jsonLd", MetadataUtils.getString(metadata, RDFFormat.JSONLD));
         return mav;
-    }   
+    }
 
     /**
      * Get distribution metadata
@@ -317,28 +290,23 @@ public class MetadataController {
      * @param id
      * @param request
      * @param response
-     * @return Metadata about the dataset distribution in one of the acceptable
-     * formats (RDF Turtle, JSON-LD, RDF XML and RDF N3)
+     * @return Metadata about the dataset distribution in one of the acceptable formats (RDF Turtle,
+     * JSON-LD, RDF XML and RDF N3)
      *
      * @throws FairMetadataServiceException
      */
     @ApiOperation(value = "Dataset distribution metadata")
-    @RequestMapping(value = "/distribution/{id}",
-            produces = {"text/turtle",
-                "application/ld+json", "application/rdf+xml", "text/n3"},
-            method = RequestMethod.GET)
+    @RequestMapping(value = "/distribution/{id}", produces = {"text/turtle", "application/ld+json",
+        "application/rdf+xml", "text/n3"}, method = RequestMethod.GET)
     @ResponseStatus(HttpStatus.OK)
-    public DistributionMetadata getDistribution(
-            @PathVariable final String id,
-            HttpServletRequest request,
-            HttpServletResponse response) throws FairMetadataServiceException,
-            ResourceNotFoundException {
-        LOGGER.info("Request to get dataset's distribution wih ID ",
-                id);
+    public DistributionMetadata getDistribution(@PathVariable final String id,
+            HttpServletRequest request, HttpServletResponse response) throws 
+            FairMetadataServiceException, ResourceNotFoundException {
+        LOGGER.info("Request to get dataset's distribution wih ID ", id);
         LOGGER.info("GET : " + request.getRequestURL());
         String uri = getRequesedURL(request);
-        DistributionMetadata metadata = fairMetaDataService.
-                retrieveDistributionMetaData(valueFactory.createIRI(uri));
+        DistributionMetadata metadata = fairMetaDataService.retrieveDistributionMetaData(
+                valueFactory.createIRI(uri));
         LoggerUtils.logRequest(LOGGER, request, response);
         return metadata;
     }
@@ -346,16 +314,15 @@ public class MetadataController {
     @ApiIgnore
     @RequestMapping(value = "/distribution/{id}", method = RequestMethod.GET,
             produces = MediaType.TEXT_HTML_VALUE)
-    public ModelAndView getHtmlDistributionMetadata(HttpServletRequest request)
-            throws FairMetadataServiceException, ResourceNotFoundException,
-            MetadataException {
+    public ModelAndView getHtmlDistributionMetadata(HttpServletRequest request) throws 
+            FairMetadataServiceException, ResourceNotFoundException, MetadataException {
         ModelAndView mav = new ModelAndView("distribution");
         String uri = getRequesedURL(request);
-        DistributionMetadata metadata = fairMetaDataService.
-                retrieveDistributionMetaData(valueFactory.createIRI(uri));
+        DistributionMetadata metadata = fairMetaDataService.retrieveDistributionMetaData(
+                valueFactory.createIRI(uri));
         mav.addObject("metadata", metadata);
-        mav.addObject("jsonLd", MetadataUtils.getString(metadata,
-                RDFFormat.JSONLD, MetadataUtils.SCHEMA_DOT_ORG_MODEL));
+        mav.addObject("jsonLd", MetadataUtils.getString(metadata, RDFFormat.JSONLD,
+                MetadataUtils.SCHEMA_DOT_ORG_MODEL));
         return mav;
     }
 
@@ -370,19 +337,20 @@ public class MetadataController {
      * @throws nl.dtls.fairdatapoint.service.FairMetadataServiceException
      */
     @ApiOperation(value = "Update fdp metadata")
-    @RequestMapping(method = RequestMethod.PATCH, consumes = {"text/turtle"})
+    @RequestMapping(method = RequestMethod.PATCH, consumes = {"text/turtle"},
+            produces = {"text/turtle"})
     @ResponseStatus(HttpStatus.OK)
-    public String updateFDPMetaData(final HttpServletRequest request,
-            HttpServletResponse response,
-            @RequestBody(required = true) FDPMetadata metadata) throws
+    public FDPMetadata updateFDPMetaData(final HttpServletRequest request,
+            HttpServletResponse response, @RequestBody(required = true) FDPMetadata metadata) throws
             FairMetadataServiceException, MetadataException {
         String uri = getRequesedURL(request);
+        
         if (!isFDPMetaDataAvailable(uri)) {
             storeDefaultFDPMetadata(uri);
         }
-        fairMetaDataService.updateFDPMetaData(valueFactory.createIRI(uri),
-                metadata);
-        return "Metadata is updated";
+        
+        fairMetaDataService.updateFDPMetaData(valueFactory.createIRI(uri), metadata);
+        return fairMetaDataService.retrieveFDPMetaData(valueFactory.createIRI(uri));
     }
 
     /**
@@ -397,21 +365,21 @@ public class MetadataController {
      * @throws nl.dtls.fairdatapoint.service.FairMetadataServiceException
      */
     @ApiOperation(value = "POST catalog metadata")
-    @RequestMapping(value = "/catalog",
-            method = RequestMethod.POST, consumes = {"text/turtle"})
+    @RequestMapping(value = "/catalog", method = RequestMethod.POST, consumes = {"text/turtle"},
+            produces = {"text/turtle"})
     @ResponseStatus(HttpStatus.CREATED)
-    public String storeCatalogMetaData(final HttpServletRequest request,
-            HttpServletResponse response,
-            @RequestBody(required = true) CatalogMetadata metadata,
-            @RequestParam("id") String id) throws
-            FairMetadataServiceException, MetadataException {
+    public CatalogMetadata storeCatalogMetaData(final HttpServletRequest request,
+            HttpServletResponse response, @RequestBody(required = true) CatalogMetadata metadata,
+            @RequestParam("id") String id) throws FairMetadataServiceException, MetadataException {
         String trimmedId = trimmer(id);
-        LOGGER.info("Request to store catalog metatdata with ID ", trimmedId);         
+        LOGGER.info("Request to store catalog metatdata with ID ", trimmedId);
         String requestedURL = getRequesedURL(request);
         String fURI = requestedURL.replace("/catalog", "");
+        
         if (!isFDPMetaDataAvailable(fURI)) {
             storeDefaultFDPMetadata(fURI);
         }
+        
         IRI uri = valueFactory.createIRI(requestedURL + "/" + trimmedId);
         metadata.setUri(uri);
         IRI fdpURI = valueFactory.createIRI(fURI);
@@ -421,7 +389,7 @@ public class MetadataController {
         metadata.setDatasets(new ArrayList());
         fairMetaDataService.storeCatalogMetaData(metadata);
         response.addHeader(HttpHeaders.LOCATION, uri.toString());
-        return "Metadata is stored";
+        return fairMetaDataService.retrieveCatalogMetaData(uri);
     }
 
     /**
@@ -437,14 +405,12 @@ public class MetadataController {
      * @throws nl.dtls.fairdatapoint.service.FairMetadataServiceException
      */
     @ApiOperation(value = "POST dataset metadata")
-    @RequestMapping(value = "/dataset", method = RequestMethod.POST,
-            consumes = {"text/turtle"})
+    @RequestMapping(value = "/dataset", method = RequestMethod.POST, consumes = {"text/turtle"},
+            produces = {"text/turtle"})
     @ResponseStatus(HttpStatus.CREATED)
-    public String storeDatasetMetaData(final HttpServletRequest request,
-            HttpServletResponse response,
-            @RequestBody(required = true) DatasetMetadata metadata,
-            @RequestParam("id") String id)
-            throws FairMetadataServiceException, MetadataException {
+    public DatasetMetadata storeDatasetMetaData(final HttpServletRequest request,
+            HttpServletResponse response, @RequestBody(required = true) DatasetMetadata metadata,
+            @RequestParam("id") String id) throws FairMetadataServiceException, MetadataException {
         String trimmedId = trimmer(id);
         LOGGER.info("Request to store dataset metatdata with ID ", trimmedId);
         String requestedURL = getRequesedURL(request);
@@ -454,9 +420,9 @@ public class MetadataController {
         metadata.setDistributions(new ArrayList());
         fairMetaDataService.storeDatasetMetaData(metadata);
         response.addHeader(HttpHeaders.LOCATION, uri.toString());
-        return "Metadata is stored";
+        return fairMetaDataService.retrieveDatasetMetaData(uri);
     }
-    
+
     /**
      * To handle POST datarecord metadata request.
      *
@@ -470,23 +436,20 @@ public class MetadataController {
      * @throws nl.dtls.fairdatapoint.service.FairMetadataServiceException
      */
     @ApiOperation(value = "POST datarecord metadata")
-    @RequestMapping(value = "/datarecord",
-            method = RequestMethod.POST, consumes = {"text/turtle"})
+    @RequestMapping(value = "/datarecord", method = RequestMethod.POST, consumes = {"text/turtle"},
+            produces = {"text/turtle"})
     @ResponseStatus(HttpStatus.CREATED)
-    public String storeDataRecord(final HttpServletRequest request,
-            HttpServletResponse response,
-            @RequestBody(required = true) DataRecordMetadata metadata,
-            @RequestParam("id") String id)
-            throws FairMetadataServiceException, MetadataException {
+    public DataRecordMetadata storeDataRecord(final HttpServletRequest request,
+            HttpServletResponse response, @RequestBody(required = true) DataRecordMetadata metadata,
+            @RequestParam("id") String id) throws FairMetadataServiceException, MetadataException {
         String trimmedId = trimmer(id);
-        LOGGER.info("Request to store datarecord metatdata with ID ",
-                trimmedId);
+        LOGGER.info("Request to store datarecord metatdata with ID ", trimmedId);
         String requestedURL = getRequesedURL(request);
         IRI uri = valueFactory.createIRI(requestedURL + "/" + trimmedId);
         metadata.setUri(uri);
         fairMetaDataService.storeDataRecordMetaData(metadata);
         response.addHeader(HttpHeaders.LOCATION, uri.toString());
-        return "Metadata is stored";
+        return fairMetaDataService.retrieveDataRecordMetadata(uri);
     }
 
     /**
@@ -503,22 +466,20 @@ public class MetadataController {
      */
     @ApiOperation(value = "POST distribution metadata")
     @RequestMapping(value = "/distribution",
-            method = RequestMethod.POST, consumes = {"text/turtle"})
+            method = RequestMethod.POST, consumes = {"text/turtle"}, produces = {"text/turtle"})
     @ResponseStatus(HttpStatus.CREATED)
-    public String storeDistribution(final HttpServletRequest request,
-            HttpServletResponse response,
-            @RequestBody(required = true) DistributionMetadata metadata,
-            @RequestParam("id") String id)
+    public DistributionMetadata storeDistribution(final HttpServletRequest request,
+            HttpServletResponse response, @RequestBody(required = true)
+                    DistributionMetadata metadata, @RequestParam("id") String id)
             throws FairMetadataServiceException, MetadataException {
         String trimmedId = trimmer(id);
-        LOGGER.info("Request to store distribution metatdata with ID ",
-                trimmedId);
+        LOGGER.info("Request to store distribution metatdata with ID ", trimmedId);
         String requestedURL = getRequesedURL(request);
         IRI uri = valueFactory.createIRI(requestedURL + "/" + trimmedId);
         metadata.setUri(uri);
         fairMetaDataService.storeDistributionMetaData(metadata);
         response.addHeader(HttpHeaders.LOCATION, uri.toString());
-        return "Metadata is stored";
+        return fairMetaDataService.retrieveDistributionMetaData(uri);
     }
 
     /**
@@ -530,49 +491,52 @@ public class MetadataController {
     private String getRequesedURL(HttpServletRequest request) {
         String url = request.getRequestURL().toString();
         LOGGER.info("Original requesed url " + url);
+        
         if (url.endsWith("/")) {
             url = url.substring(0, url.length() - 1);
-        }      
-        List<String> rdfExt =  RDFWriterRegistry.getInstance()
-                .getKeys().stream()
-                    .map(RDFFormat::getDefaultFileExtension)
-                    .collect(Collectors.toList());
+        }
         
+        List<String> rdfExt = RDFWriterRegistry.getInstance().getKeys().stream()
+                .map(RDFFormat::getDefaultFileExtension).collect(Collectors.toList());
+
         for (String ext : rdfExt) {
             String extension = "." + ext;
-            if(url.contains(extension)) {
+            if (url.contains(extension)) {
                 LOGGER.info("Found RDF extension in url : " + ext);
                 url = url.replace(extension, "");
                 break;
-            }            
+            }
         }
         try {
-            URL requestedURL = new URL(url);            
+            URL requestedURL = new URL(url);
             String host = request.getHeader("x-forwarded-host");
             String proto = request.getHeader("x-forwarded-proto");
             String port = request.getHeader("x-forwarded-port");
-            if(host != null && !host.isEmpty()){                
+            
+            if (host != null && !host.isEmpty()) {
                 url = url.replace(requestedURL.getHost(), host);
             }
-            if(proto != null && !proto.isEmpty()){
+            
+            if (proto != null && !proto.isEmpty()) {
                 url = url.replace(requestedURL.getProtocol(), proto);
-            }            
-            if(port != null && requestedURL.getPort() != -1){                
+            }
+            
+            if (port != null && requestedURL.getPort() != -1) {
                 String val = ":" + String.valueOf(requestedURL.getPort());
                 LOGGER.info("x-forwarded-port " + port);
-                switch (port){ 
-                    case "443":                    
-                        url = url.replace(val, "");                    
+                switch (port) {
+                    case "443":
+                        url = url.replace(val, "");
                         break;
                     case "80":
                         url = url.replace(val, "");
                         break;
                     default:
-                        break;            
+                        break;
                 }
             }
-        } catch (MalformedURLException ex) {             
-            LOGGER.error("Error creating url  ", ex.getMessage());             
+        } catch (MalformedURLException ex) {
+            LOGGER.error("Error creating url  ", ex.getMessage());
             return null;
         }
         LOGGER.info("Modified requesed url " + url);
@@ -592,34 +556,13 @@ public class MetadataController {
             String host = new URL(fdpUrl).getAuthority();
             FDPMetadata metadata = new FDPMetadata();
             metadata.setUri(valueFactory.createIRI(fdpUrl));
-            metadata.setTitle(valueFactory.createLiteral("FDP of " + host,
-                    XMLSchema.STRING));
-            metadata.setDescription(valueFactory.createLiteral(
-                    "FDP of " + host, XMLSchema.STRING));
-            metadata.setLanguage(valueFactory.createIRI(
-                    "http://id.loc.gov/vocabulary/iso639-1/en"));
-            metadata.setLicense(valueFactory.createIRI(
-                    "http://rdflicense.appspot.com/rdflicense/cc-by-nc-nd3.0"));
-            metadata.setVersion(valueFactory.createLiteral(
-                    "1.0", XMLSchema.FLOAT));
-            metadata.setSwaggerDoc(valueFactory.createIRI(
-                    fdpUrl + "/swagger-ui.html"));
-            metadata.setInstitutionCountry(valueFactory.createIRI(
-                    "http://lexvo.org/id/iso3166/NL"));   
-            Agent publisher = new Agent();
-            publisher.setUri(valueFactory.createIRI("http://dtls.nl"));
-            publisher.setType(FOAF.ORGANIZATION);
-            publisher.setName(valueFactory.createLiteral("DTLS",
-                    XMLSchema.STRING));
-            metadata.setPublisher(publisher);
-            metadata.setInstitution(publisher);
+            metadata.setTitle(valueFactory.createLiteral("FDP of " + host, XMLSchema.STRING));
+            metadata.setVersion(valueFactory.createLiteral("1.0", XMLSchema.FLOAT));
             fairMetaDataService.storeFDPMetaData(metadata);
-        } catch (MalformedURLException | MetadataException
-                | FairMetadataServiceException ex) {
-            throw new MetadataParserException(
-                    "Error creating generic FDP meatdata " + ex.getMessage());
+        } catch (MalformedURLException | MetadataException | FairMetadataServiceException ex) {
+            throw new MetadataParserException("Error creating generic FDP meatdata " + 
+                    ex.getMessage());
         }
-
     }
 
     /**

--- a/src/test/java/nl/dtls/fairdatapoint/api/controller/MetadataControllerTest.java
+++ b/src/test/java/nl/dtls/fairdatapoint/api/controller/MetadataControllerTest.java
@@ -41,6 +41,7 @@ import org.apache.http.HttpHeaders;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
+import static org.eclipse.rdf4j.rio.RDFFormat.TURTLE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import org.junit.Before;
@@ -214,22 +215,22 @@ public class MetadataControllerTest {
         request.setRequestURI(TEST_FDP_PATH);
         handler = handlerMapping.getHandler(request).getHandler();
         handlerAdapter.handle(request, response, handler);
-        assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+        assertEquals(TURTLE.getDefaultMIMEType(), response.getContentType());
 
         request.setRequestURI(TEST_CATALOG_PATH);
         handler = handlerMapping.getHandler(request).getHandler();
         handlerAdapter.handle(request, response, handler);
-        assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+        assertEquals(TURTLE.getDefaultMIMEType(), response.getContentType());
 
         request.setRequestURI(TEST_DATASET_PATH);
         handler = handlerMapping.getHandler(request).getHandler();
         handlerAdapter.handle(request, response, handler);
-        assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+        assertEquals(TURTLE.getDefaultMIMEType(), response.getContentType());
 
         request.setRequestURI(TEST_DISTRIBUTION_PATH);
         handler = handlerMapping.getHandler(request).getHandler();
         handlerAdapter.handle(request, response, handler);
-        assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+        assertEquals(TURTLE.getDefaultMIMEType(), response.getContentType());
     }
 
     /**


### PR DESCRIPTION
In the previous implementation the default content type is HTML. This is, however problematic for tools like demonstrator to use FDP, since demonstrator uses blazegraph's API to store the metadata and we can't supply accept header to the blazegraph API calls. I have changed the default content type to text/turtle and I also changed the response of the metadata POST calls for response with metadata as a turtle string. I also modified controller's unit method to check the default content type