### PR TITLE
FAIRMetataMetric implemation 

### DIFF
--- a/config/fdp-server.properties
+++ b/config/fdp-server.properties
@@ -1,5 +1,0 @@
-# To change this license header, choose License Headers in Project Properties.
-# To change this template file, choose Tools | Templates
-# and open the template in the editor.
-
-base-uri=http://localhost:9095/

--- a/config/triple-store.properties
+++ b/config/triple-store.properties
@@ -1,9 +1,0 @@
-# To change this license header, choose License Headers in Project Properties.
-# To change this template file, choose Tools | Templates
-# and open the template in the editor.
-
-# valid store type options { 1 = inMemoryStore , 2 = http SPARQLRepository }
-store-type=1
-store-prepopulate=true
-store-url=http://agraph.biosemantics.org/catalogs/rajatest/repositories/fdp
-

--- a/src/main/java/nl/dtls/fairdatapoint/repository/impl/StoreManagerImpl.java
+++ b/src/main/java/nl/dtls/fairdatapoint/repository/impl/StoreManagerImpl.java
@@ -82,7 +82,7 @@ public class StoreManagerImpl implements StoreManager {
             }
             return statements;
         } catch (RepositoryException e) {
-            throw (new StoreManagerException("Error retrieve resource :" + e.getMessage()));
+            throw new StoreManagerException("Error retrieve resource :" + e.getMessage());
         }
     }
 

--- a/src/main/java/nl/dtls/fairdatapoint/repository/impl/StoreManagerImpl.java
+++ b/src/main/java/nl/dtls/fairdatapoint/repository/impl/StoreManagerImpl.java
@@ -28,13 +28,13 @@
 package nl.dtls.fairdatapoint.repository.impl;
 
 import com.google.common.base.Preconditions;
-import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import nl.dtls.fairdatapoint.repository.StoreManager;
 import nl.dtls.fairdatapoint.repository.StoreManagerException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
@@ -76,10 +76,7 @@ public class StoreManagerImpl implements StoreManager {
         LOGGER.info("Get statements for the URI <" + uri.toString() + ">");
         try (RepositoryConnection conn = getRepositoryConnection()) {
             RepositoryResult<Statement> queryResult = conn.getStatements(null, null, null, uri);
-            List<Statement> statements = new ArrayList();
-            while (queryResult.hasNext()) {
-                statements.add(queryResult.next());
-            }
+            List<Statement> statements = Iterations.asList(queryResult);
             return statements;
         } catch (RepositoryException e) {
             throw new StoreManagerException("Error retrieve resource :" + e.getMessage());

--- a/src/main/java/nl/dtls/fairdatapoint/repository/impl/StoreManagerImpl.java
+++ b/src/main/java/nl/dtls/fairdatapoint/repository/impl/StoreManagerImpl.java
@@ -71,21 +71,18 @@ public class StoreManagerImpl implements StoreManager {
      * @throws StoreManagerException
      */
     @Override
-    public List<Statement> retrieveResource(@Nonnull IRI uri)
-            throws StoreManagerException {
+    public List<Statement> retrieveResource(@Nonnull IRI uri) throws StoreManagerException {
         Preconditions.checkNotNull(uri, "URI must not be null.");
         LOGGER.info("Get statements for the URI <" + uri.toString() + ">");
         try (RepositoryConnection conn = getRepositoryConnection()) {
-            RepositoryResult<Statement> queryResult = conn.getStatements(uri,
-                    null, null, false);
+            RepositoryResult<Statement> queryResult = conn.getStatements(null, null, null, uri);
             List<Statement> statements = new ArrayList();
             while (queryResult.hasNext()) {
                 statements.add(queryResult.next());
             }
             return statements;
         } catch (RepositoryException e) {
-            throw (new StoreManagerException("Error retrieve resource :"
-                    + e.getMessage()));
+            throw (new StoreManagerException("Error retrieve resource :" + e.getMessage()));
         }
     }
 

--- a/src/main/java/nl/dtls/fairdatapoint/service/FairMetaDataMetricsService.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/FairMetaDataMetricsService.java
@@ -1,0 +1,53 @@
+/**
+ * The MIT License
+ * Copyright © 2017 DTL
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package nl.dtls.fairdatapoint.service;
+
+import java.util.List;
+import javax.annotation.Nonnull;
+import nl.dtl.fairmetadata4j.model.Metric;
+import org.eclipse.rdf4j.model.IRI;
+
+/**
+ * Fair metrics service interface
+ * 
+ * @author Rajaram Kaliyaperumal <rr.kaliyaperumal@gmail.com>
+ * @author Kees Burger <kees.burger@dtls.nl>
+ * @since 2018-01-26
+ * @version 0.1
+ */
+public interface FairMetaDataMetricsService {
+    
+    /**
+     * This method returns list of fair metrics for the given metadata URI
+     * 
+     * @param metadataURI metadata URI
+     * @return List of fair metrics
+     */
+    List<Metric> getMetrics(@Nonnull IRI metadataURI);
+    
+}

--- a/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataMetricsServiceImpl.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataMetricsServiceImpl.java
@@ -32,13 +32,14 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import nl.dtl.fairmetadata4j.model.Metric;
+import nl.dtls.fairdatapoint.service.FairMetaDataMetricsService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 /**
  * Service layer for fair metric
@@ -48,8 +49,8 @@ import org.springframework.stereotype.Service;
  * @since 2018-01-16
  * @version 0.1
  */
-@Service("fairMetaDataMetricsServiceImpl")
-public class FairMetaDataMetricsServiceImpl {
+@Component
+public class FairMetaDataMetricsServiceImpl implements FairMetaDataMetricsService {
     
     private static final Logger LOGGER = LogManager.getLogger(FairMetaDataServiceImpl.class
             .getName());
@@ -57,16 +58,16 @@ public class FairMetaDataMetricsServiceImpl {
     private final ValueFactory valueFactory = SimpleValueFactory.getInstance();
     
     @Value("${metadataFM.F1.A:nil}")
-    private String mdFmF1A;
+    private String metricFindablity1A;
     
     @Value("${metadataFM.F1.B:nil}")
-    private String mdFmF1B;
+    private String metricFindablity1B;
     
     @Value("${metadataFM.A1.A:nil}")
-    private String mdFmA11;
+    private String metricAccessiblity1A;
     
     @Value("${metadataFM.A2:nil}")
-    private String mdFmA2;
+    private String metricAccessiblity2;
     
     /**
      * This method returns list of fair metrics for metadata
@@ -80,16 +81,16 @@ public class FairMetaDataMetricsServiceImpl {
         List<Metric> metrics = new ArrayList();
         
         addMetric(metrics, metadataURI.toString().concat("/mdFmF1A"), 
-                "https://raw.githubusercontent.com/FAIRMetrics/Metrics/master/FM_F1A", mdFmF1A);
+                "https://raw.githubusercontent.com/FAIRMetrics/Metrics/master/FM_F1A", metricFindablity1A);
         
         addMetric(metrics, metadataURI.toString().concat("/mdFmF1B"), 
-                "https://raw.githubusercontent.com/FAIRMetrics/Metrics/master/FM_F1B", mdFmF1B);
+                "https://raw.githubusercontent.com/FAIRMetrics/Metrics/master/FM_F1B", metricFindablity1B);
         
         addMetric(metrics, metadataURI.toString().concat("/mdFmA1_1"), 
-                "https://raw.githubusercontent.com/FAIRMetrics/Metrics/master/FM_A1.1", mdFmA11);
+                "https://raw.githubusercontent.com/FAIRMetrics/Metrics/master/FM_A1.1", metricAccessiblity1A);
         
         addMetric(metrics, metadataURI.toString().concat("/mdFmA2"), 
-                "https://raw.githubusercontent.com/FAIRMetrics/Metrics/master/FM_A2", mdFmA2);
+                "https://raw.githubusercontent.com/FAIRMetrics/Metrics/master/FM_A2", metricAccessiblity2);
         return metrics;
     }
     

--- a/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataMetricsServiceImpl.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataMetricsServiceImpl.java
@@ -1,0 +1,124 @@
+/**
+ * The MIT License
+ * Copyright © 2017 DTL
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package nl.dtls.fairdatapoint.service.impl;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import nl.dtl.fairmetadata4j.model.Metric;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service layer for fair metric
+ *
+ * @author Rajaram Kaliyaperumal <rr.kaliyaperumal@gmail.com>
+ * @author Kees Burger <kees.burger@dtls.nl>
+ * @since 2018-01-16
+ * @version 0.1
+ */
+@Service("fairMetaDataMetricsServiceImpl")
+public class FairMetaDataMetricsServiceImpl {
+    
+    private final ValueFactory valueFactory = SimpleValueFactory.getInstance();
+    
+    private final static Logger LOGGER
+            = LogManager.getLogger(FairMetaDataServiceImpl.class.getName());
+    
+    @Value("${metadataFM.F1.A:nil}")
+    private String mdFmF1A;
+    
+    @Value("${metadataFM.F1.B:nil}")
+    private String mdFmF1B;
+    
+    @Value("${metadataFM.A1.A:nil}")
+    private String mdFmA11;
+    
+    @Value("${metadataFM.A2:nil}")
+    private String mdFmA2;
+    
+    /**
+     * This method returns list of fair metrics for metadata
+     * 
+     * @param metadataURI metadata URI
+     * @return List of fair metrics
+     */
+    public List<Metric> getMetrics(@Nonnull IRI metadataURI) {
+        
+        Preconditions.checkNotNull(metadataURI, "Metadata URI must not be null.");  
+        List<Metric> metrics = new ArrayList();
+        
+        addMetric(metrics, metadataURI.toString().concat("/mdFmF1A"), 
+                "https://raw.githubusercontent.com/FAIRMetrics/Metrics/master/FM_F1A", mdFmF1A);
+        
+        addMetric(metrics, metadataURI.toString().concat("/mdFmF1B"), 
+                "https://raw.githubusercontent.com/FAIRMetrics/Metrics/master/FM_F1B", mdFmF1B);
+        
+        addMetric(metrics, metadataURI.toString().concat("/mdFmA1_1"), 
+                "https://raw.githubusercontent.com/FAIRMetrics/Metrics/master/FM_A1.1", mdFmA11);
+        
+        addMetric(metrics, metadataURI.toString().concat("/mdFmA2"), 
+                "https://raw.githubusercontent.com/FAIRMetrics/Metrics/master/FM_A2", mdFmA2);
+        return metrics;
+    }
+    
+    /**
+     * We are using this method to reduce the NPath complexity measure. This method add a FM to the
+     * list if the metric valueUri URI is provided.
+     * 
+     * @param metrics   List<Mertic> object
+     * @param uri   Metric uri
+     * @param typeUri  Metric typeUri uri
+     * @param valueUri Metric valueUri uri
+     */
+    private void addMetric(List<Metric> metrics, String uri, String typeUri, String valueUri) { 
+        
+        try{
+            Preconditions.checkNotNull(uri, "Metadata URI must not be null.");  
+            Preconditions.checkState(!uri.isEmpty(), "Metadata URI must not be empty.");  
+            Preconditions.checkNotNull(typeUri, "Type URI must not be null.");  
+            Preconditions.checkState(!typeUri.isEmpty(), "Type URI must not be empty."); 
+            Preconditions.checkNotNull(valueUri, "Value URI must not be null.");  
+            Preconditions.checkState(!valueUri.isEmpty(), "Value URI must not be empty.");  
+            
+            Metric m = new Metric();
+            m.setUri(valueFactory.createIRI(uri));
+            m.setMetricType(valueFactory.createIRI(typeUri));
+            m.setValue(valueFactory.createIRI(valueUri));
+            metrics.add(m);
+        } catch (Exception e){
+            LOGGER.info(e.getMessage());            
+        }            
+    } 
+}

--- a/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataMetricsServiceImpl.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataMetricsServiceImpl.java
@@ -53,8 +53,8 @@ public class FairMetaDataMetricsServiceImpl {
     
     private final ValueFactory valueFactory = SimpleValueFactory.getInstance();
     
-    private final static Logger LOGGER
-            = LogManager.getLogger(FairMetaDataServiceImpl.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(
+            FairMetaDataServiceImpl.class.getName());
     
     @Value("${metadataFM.F1.A:nil}")
     private String mdFmF1A;

--- a/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataMetricsServiceImpl.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataMetricsServiceImpl.java
@@ -51,10 +51,10 @@ import org.springframework.stereotype.Service;
 @Service("fairMetaDataMetricsServiceImpl")
 public class FairMetaDataMetricsServiceImpl {
     
-    private final ValueFactory valueFactory = SimpleValueFactory.getInstance();
+    private static final Logger LOGGER = LogManager.getLogger(FairMetaDataServiceImpl.class
+            .getName());
     
-    private static final Logger LOGGER = LogManager.getLogger(
-            FairMetaDataServiceImpl.class.getName());
+    private final ValueFactory valueFactory = SimpleValueFactory.getInstance();
     
     @Value("${metadataFM.F1.A:nil}")
     private String mdFmF1A;

--- a/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImpl.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImpl.java
@@ -101,6 +101,8 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
     private IRI license;    
     @Autowired
     private FairSearchClient fseService;
+    @Autowired
+    private FairMetaDataMetricsServiceImpl fmMetricsService;
 
     @org.springframework.beans.factory.annotation.Value("${metadataProperties.rootSpecs:nil}")
     private String fdpSpecs;
@@ -345,6 +347,8 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
         if (metadata.getLicense() == null && license != null) {
             metadata.setLicense(license);
         }
+        //Add FAIR metrics
+        metadata.setMetrics(fmMetricsService.getMetrics(metadata.getUri()));
     }
     
     /**
@@ -433,7 +437,6 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
                 String msg = ("No metadata found for the uri : " + uri);
                 throw (new ResourceNotFoundException(msg));
             }
-            addAddtionalResource(statements);
             return statements;
         } catch (StoreManagerException ex) {
             LOGGER.error("Error retrieving fdp metadata from the store");
@@ -460,30 +463,7 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
         }
         return isURIExist;
     }
-
-    private void addAddtionalResource(List<Statement> statements) throws
-            StoreManagerException {
-        List<Statement> otherResources = new ArrayList<>();
-        for (Statement st : statements) {
-            IRI predicate = st.getPredicate();
-            Value object = st.getObject();
-            if (predicate.equals(FDP.METADATAIDENTIFIER)) {
-                otherResources.addAll(storeManager.retrieveResource(
-                        (IRI) object));
-            } else if (predicate.equals(R3D.INSTITUTION)) {
-                otherResources.addAll(storeManager.retrieveResource(
-                        (IRI) object));
-            } else if (predicate.equals(DCTERMS.PUBLISHER)) {
-                otherResources.addAll(storeManager.retrieveResource(
-                        (IRI) object));
-            } else if (predicate.equals(R3D.REPOSITORYIDENTIFIER)) {
-                otherResources.addAll(storeManager.retrieveResource(
-                        (IRI) object));
-            }
-        }
-        statements.addAll(otherResources);
-    }
-
+    
     @Override
     public void updateFDPMetaData(IRI uri, FDPMetadata metaDataUpdate)
             throws FairMetadataServiceException, MetadataException {

--- a/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImpl.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImpl.java
@@ -55,6 +55,7 @@ import nl.dtl.fairmetadata4j.utils.vocabulary.FDP;
 import nl.dtl.fairmetadata4j.utils.vocabulary.R3D;
 import nl.dtls.fairdatapoint.repository.StoreManager;
 import nl.dtls.fairdatapoint.repository.StoreManagerException;
+import nl.dtls.fairdatapoint.service.FairMetaDataMetricsService;
 import nl.dtls.fairdatapoint.service.FairMetaDataService;
 import nl.dtls.fairdatapoint.service.FairMetadataServiceException;
 import nl.dtls.fairdatapoint.service.FairSearchClient;
@@ -62,11 +63,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.DCAT;
-import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -102,7 +101,7 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
     @Autowired
     private FairSearchClient fseService;
     @Autowired
-    private FairMetaDataMetricsServiceImpl fmMetricsService;
+    private FairMetaDataMetricsService fmMetricsService;
 
     @org.springframework.beans.factory.annotation.Value("${metadataProperties.rootSpecs:nil}")
     private String fdpSpecs;

--- a/src/main/resources/conf/fdpConfig.yml
+++ b/src/main/resources/conf/fdpConfig.yml
@@ -19,3 +19,10 @@ metadataProperties:
 fairSearch:
     fdpSubmitUrl: http://localhost:8080/fse/submitFdp
 threadPoolSize: 4
+metadataFM:
+    F1:
+        A: http://example.com/THIS_IS_A_PH_URI_4_ID_SCHEME
+        B: http://example.com/THIS_IS_A_PH_URI_4_ID_PERSISTENCE
+    A1:
+        A: http://example.com/THIS_IS_A_PH_URI_4_ACCESS_PROTOCOL
+    A2: http://example.com/THIS_IS_A_PH_URI_4_MD_LONGEVITY

--- a/src/test/java/nl/dtls/fairdatapoint/repository/impl/StoreManagerImplTest.java
+++ b/src/test/java/nl/dtls/fairdatapoint/repository/impl/StoreManagerImplTest.java
@@ -75,7 +75,7 @@ public class StoreManagerImplTest {
         List<Statement> sts = ExampleFilesUtils.
                 getFileContentAsStatements(ExampleFilesUtils.VALID_TEST_FILE,
                         "http://www.dtls.nl/test");
-        testStoreManager.storeStatements(sts);
+        testStoreManager.storeStatements(sts, f.createIRI(ExampleFilesUtils.TEST_SUB_URI));
     }
 
     /**

--- a/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataMetricsServiceImplTest.java
+++ b/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataMetricsServiceImplTest.java
@@ -30,6 +30,7 @@ package nl.dtls.fairdatapoint.service.impl;
 import java.util.List;
 import nl.dtl.fairmetadata4j.model.Metric;
 import nl.dtls.fairdatapoint.api.config.RestApiContext;
+import nl.dtls.fairdatapoint.service.FairMetaDataMetricsService;
 import nl.dtls.fairdatapoint.utils.ExampleFilesUtils;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -55,7 +56,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
 public class FairMetaDataMetricsServiceImplTest {    
     
     @Autowired
-    private FairMetaDataMetricsServiceImpl fmMetricsServiceImpl;
+    private FairMetaDataMetricsService fmMetricsServiceImpl;
     
     private final ValueFactory valueFactory = SimpleValueFactory.getInstance();
     

--- a/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataMetricsServiceImplTest.java
+++ b/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataMetricsServiceImplTest.java
@@ -1,0 +1,80 @@
+/**
+ * The MIT License
+ * Copyright © 2017 DTL
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package nl.dtls.fairdatapoint.service.impl;
+
+import java.util.List;
+import nl.dtl.fairmetadata4j.model.Metric;
+import nl.dtls.fairdatapoint.api.config.RestApiContext;
+import nl.dtls.fairdatapoint.utils.ExampleFilesUtils;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+/**
+ * FairMetaDataMetricsServiceImpl class unit tests
+ *
+ * @author Rajaram Kaliyaperumal <rr.kaliyaperumal@gmail.com>
+ * @author Kees Burger <kees.burger@dtls.nl>
+ * @since 2018-01-19
+ * @version 0.1
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(classes = {RestApiContext.class})
+public class FairMetaDataMetricsServiceImplTest {    
+    
+    @Autowired
+    private FairMetaDataMetricsServiceImpl fmMetricsServiceImpl;
+    
+    private final ValueFactory valueFactory = SimpleValueFactory.getInstance();
+    
+    /**
+     * Test getMetrics with null uri, this test is excepted to throw error
+     */
+    @Test(expected = NullPointerException.class)
+    public void nullMetdataUri() throws Exception {
+        fmMetricsServiceImpl.getMetrics(null);
+    }
+    
+    /**
+     * This test is excepted to pass
+     */
+    @Test
+    public void validMetdataUri() throws Exception {
+        List<Metric> m = fmMetricsServiceImpl.getMetrics(valueFactory.createIRI(
+                ExampleFilesUtils.FDP_URI));
+        assertTrue(m.size() > 0);
+    }
+    
+}

--- a/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImplTest.java
+++ b/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImplTest.java
@@ -39,6 +39,7 @@ import nl.dtl.fairmetadata4j.model.DistributionMetadata;
 import nl.dtl.fairmetadata4j.model.FDPMetadata;
 import nl.dtls.fairdatapoint.api.config.RestApiTestContext;
 import nl.dtls.fairdatapoint.repository.StoreManagerException;
+import nl.dtls.fairdatapoint.service.FairMetaDataMetricsService;
 import nl.dtls.fairdatapoint.service.FairMetaDataService;
 import nl.dtls.fairdatapoint.service.FairMetadataServiceException;
 import nl.dtls.fairdatapoint.utils.ExampleFilesUtils;
@@ -305,9 +306,9 @@ public class FairMetaDataServiceImplTest {
     @Test
     public void existenceMetric() throws 
             FairMetadataServiceException, MetadataException {
-        FairMetaDataMetricsServiceImpl mockMetricsService = new FairMetaDataMetricsServiceImpl();
+        FairMetaDataMetricsService mockMetricsService = new FairMetaDataMetricsServiceImpl();
         // Using reflection to mock MetricsService field
-        ReflectionTestUtils.setField(mockMetricsService, "mdFmF1A", 
+        ReflectionTestUtils.setField(mockMetricsService, "metricFindablity1A", 
                 "http://www.example.com");
         ReflectionTestUtils.setField(fairMetaDataService, "fmMetricsService",mockMetricsService);
         // Store a catalog metadata

--- a/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImplTest.java
+++ b/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImplTest.java
@@ -46,6 +46,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -58,6 +59,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * FairMetaDataServiceImpl class unit tests
@@ -291,6 +293,29 @@ public class FairMetaDataServiceImplTest {
         FDPMetadata metadata = fairMetaDataService.retrieveFDPMetaData(
                 valueFactory.createIRI(ExampleFilesUtils.FDP_URI));
         assertNotNull(metadata.getSpecification());
+    }
+    
+    /**
+     * Test existence of mertic
+     *
+     * @throws nl.dtls.fairdatapoint.service.FairMetadataServiceException
+     * @throws nl.dtl.fairmetadata4j.io.MetadataException
+     */
+    @DirtiesContext
+    @Test
+    public void existenceMetric() throws 
+            FairMetadataServiceException, MetadataException {
+        FairMetaDataMetricsServiceImpl mockMetricsService = new FairMetaDataMetricsServiceImpl();
+        // Using reflection to mock MetricsService field
+        ReflectionTestUtils.setField(mockMetricsService, "mdFmF1A", 
+                "http://www.example.com");
+        ReflectionTestUtils.setField(fairMetaDataService, "fmMetricsService",mockMetricsService);
+        // Store a catalog metadata
+        fairMetaDataService.storeCatalogMetaData(ExampleFilesUtils.getCatalogMetadata(
+                "http://www.example.com/cat1", ExampleFilesUtils.FDP_URI));
+        FDPMetadata metadata = fairMetaDataService.retrieveFDPMetaData(valueFactory.createIRI(
+                "http://www.example.com/cat1"));
+        assertFalse(metadata.getMetrics().isEmpty());
     }
 
     /**


### PR DESCRIPTION
I added new service layer to the API which generates metrics RDF statements for all metadata layers. The metric values are configurable, it can be done via property file. I also modified the storage layer, in the new implementation the resources are retrieved based on context URI which let me to refactor FairData service class. I remove addAdditionalResource() method in this class. Since we are retrieving resources from the store based on context URI this method is no long required. I also removed unused property files 