### PR TITLE
Default accessRights feature

### DIFF
--- a/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImpl.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImpl.java
@@ -120,7 +120,7 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
     @org.springframework.beans.factory.annotation.Value(
             "${metadataProperties.accessRightsDescription:This resource has no access restriction}")
     private String accessRightsDescription;
-    private final ValueFactory valueFactory = SimpleValueFactory.getInstance();
+    private static final ValueFactory VALUEFACTORY = SimpleValueFactory.getInstance();
 
     @Override
     public FDPMetadata retrieveFDPMetaData(@Nonnull IRI uri) throws
@@ -177,7 +177,7 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
             throws FairMetadataServiceException, MetadataException {
         Preconditions.checkNotNull(metadata, "FDPMetadata must not be null.");
         if (!fdpSpecs.isEmpty() && !fdpSpecs.contains("nil")) {
-            metadata.setSpecification(valueFactory.createIRI(fdpSpecs));
+            metadata.setSpecification(VALUEFACTORY.createIRI(fdpSpecs));
         }
         storeMetadata(metadata);
         /*
@@ -199,7 +199,7 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
 //                + "Please try with valid fdp URI");        
         if (!catalogSpecs.isEmpty()
                 && !catalogSpecs.contains("nil")) {
-            metadata.setSpecification(valueFactory.createIRI(catalogSpecs));
+            metadata.setSpecification(VALUEFACTORY.createIRI(catalogSpecs));
         }
         if (doesParentResourceExists(metadata)) {
             storeMetadata(metadata);
@@ -222,7 +222,7 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
                 + "Please try with valid catalog URI");
         if (!datasetSpecs.isEmpty()
                 && !datasetSpecs.contains("nil")) {
-            metadata.setSpecification(valueFactory.createIRI(datasetSpecs));
+            metadata.setSpecification(VALUEFACTORY.createIRI(datasetSpecs));
         }
         if (doesParentResourceExists(metadata)) {
             storeMetadata(metadata);
@@ -245,7 +245,7 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
                 + "Please try with valid dataset URI");
         if (!distributionSpecs.isEmpty()
                 && !distributionSpecs.contains("nil")) {
-            metadata.setSpecification(valueFactory.createIRI(
+            metadata.setSpecification(VALUEFACTORY.createIRI(
                     distributionSpecs));
         }
         if (doesParentResourceExists(metadata)) {
@@ -269,7 +269,7 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
                 + "Please try with valid dataset URI");
         if (!datarecordSpecs.isEmpty()
                 && !datarecordSpecs.contains("nil")) {
-            metadata.setSpecification(valueFactory.createIRI(
+            metadata.setSpecification(VALUEFACTORY.createIRI(
                     datarecordSpecs));
         }
         if (doesParentResourceExists(metadata)) {
@@ -300,10 +300,10 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
                         LOGGER.info("Repository ID is null or empty, this feild"
                                 + " value will be generated automatically");
                         Identifier id = new Identifier();
-                        id.setUri(valueFactory.createIRI(metadata.getUri().
+                        id.setUri(VALUEFACTORY.createIRI(metadata.getUri().
                                 stringValue() + "#repositoryID"));
                         UUID uid = UUID.randomUUID();
-                        id.setIdentifier(valueFactory.createLiteral(
+                        id.setIdentifier(VALUEFACTORY.createLiteral(
                                 uid.toString(), XMLSchema.STRING));
                         id.setType(DATACITE.IDENTIFIER);
                         ((FDPMetadata) metadata).setRepostoryIdentifier(id);
@@ -331,10 +331,10 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
             LOGGER.info("Metadata ID is null or empty, this feild value will "
                     + "be generated automatically");
             Identifier id = new Identifier();
-            id.setUri(valueFactory.createIRI(metadata.getUri().stringValue()
+            id.setUri(VALUEFACTORY.createIRI(metadata.getUri().stringValue()
                     + "#metadataID"));
             UUID uid = UUID.randomUUID();
-            id.setIdentifier(valueFactory.createLiteral(uid.toString(),
+            id.setIdentifier(VALUEFACTORY.createLiteral(uid.toString(),
                     XMLSchema.STRING));
             id.setType(DATACITE.RESOURCEIDENTIFIER);
             metadata.setIdentifier(id);
@@ -358,9 +358,9 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
         if (metadata.getAccessRights() == null) {
             LOGGER.info("Metadata ID is null or empty, adding default value for access rights");
             AccessRights accessRights = new AccessRights();
-            accessRights.setUri(valueFactory.createIRI(metadata.getUri().stringValue()
+            accessRights.setUri(VALUEFACTORY.createIRI(metadata.getUri().stringValue()
                     + "#accessRights"));
-            Literal description = valueFactory.createLiteral(accessRightsDescription,
+            Literal description = VALUEFACTORY.createLiteral(accessRightsDescription,
                     XMLSchema.STRING);
             accessRights.setDescription(description);
             metadata.setAccessRights(accessRights);

--- a/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImpl.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImpl.java
@@ -39,6 +39,7 @@ import nl.dtl.fairmetadata4j.io.DatasetMetadataParser;
 import nl.dtl.fairmetadata4j.io.DistributionMetadataParser;
 import nl.dtl.fairmetadata4j.io.FDPMetadataParser;
 import nl.dtl.fairmetadata4j.io.MetadataException;
+import nl.dtl.fairmetadata4j.model.AccessRights;
 import nl.dtl.fairmetadata4j.model.Agent;
 import nl.dtl.fairmetadata4j.model.CatalogMetadata;
 import nl.dtl.fairmetadata4j.model.DataRecordMetadata;
@@ -62,6 +63,7 @@ import nl.dtls.fairdatapoint.service.FairSearchClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -115,6 +117,9 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
     @org.springframework.beans.factory.annotation.Value(
             "${metadataProperties.distributionSpecs:nil}")
     private String distributionSpecs;
+    @org.springframework.beans.factory.annotation.Value(
+            "${metadataProperties.accessRightsDescription:This resource has no access restriction}")
+    private String accessRightsDescription;
     private final ValueFactory valueFactory = SimpleValueFactory.getInstance();
 
     @Override
@@ -348,6 +353,18 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
         }
         //Add FAIR metrics
         metadata.setMetrics(fmMetricsService.getMetrics(metadata.getUri()));
+        
+        // Add access rights
+        if (metadata.getAccessRights() == null) {
+            LOGGER.info("Metadata ID is null or empty, adding default value for access rights");
+            AccessRights accessRights = new AccessRights();
+            accessRights.setUri(valueFactory.createIRI(metadata.getUri().stringValue()
+                    + "#accessRights"));
+            Literal description = valueFactory.createLiteral(accessRightsDescription,
+                    XMLSchema.STRING);
+            accessRights.setDescription(description);
+            metadata.setAccessRights(accessRights);
+        }
     }
     
     /**

--- a/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImpl.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImpl.java
@@ -88,6 +88,8 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
 
     private final static Logger LOGGER
             = LogManager.getLogger(FairMetaDataServiceImpl.class);
+    
+    private static final ValueFactory VALUEFACTORY = SimpleValueFactory.getInstance();
         
     private IRI fdpUri;
     @Autowired
@@ -120,7 +122,6 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
     @org.springframework.beans.factory.annotation.Value(
             "${metadataProperties.accessRightsDescription:This resource has no access restriction}")
     private String accessRightsDescription;
-    private static final ValueFactory VALUEFACTORY = SimpleValueFactory.getInstance();
 
     @Override
     public FDPMetadata retrieveFDPMetaData(@Nonnull IRI uri) throws

--- a/src/main/resources/conf/fdpConfig.yml
+++ b/src/main/resources/conf/fdpConfig.yml
@@ -15,7 +15,8 @@ metadataProperties:
     publisherURI: http://dtls.nl
     publisherName: dtls
     language: http://id.loc.gov/vocabulary/iso639-1/en
-    license: http://rdflicense.appspot.com/rdflicense/cc-by-nc-nd3.0
+    license: http://rdflicense.appspot.com/rdflicense/cc-by-nc-nd3.0    
+    accessRightsDescription: This resource has no access restriction 
 fairSearch:
     fdpSubmitUrl: http://localhost:8080/fse/submitFdp
 threadPoolSize: 4

--- a/src/main/webapp/WEB-INF/templates/base.hbs
+++ b/src/main/webapp/WEB-INF/templates/base.hbs
@@ -8,8 +8,8 @@
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
         
         <!-- Latest compiled and minified JavaScript -->
-        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous">
-        </script>
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+        
         <title> 
             {{#if metadata.title}}
                 {{literal metadata.title}}
@@ -53,45 +53,115 @@
                     <h4>
                         <div class="col-sm-1"><span class="label label-default">Title</span></div>
                         <div class="col-sm-7"><span>{{literal metadata.title}}</span></div>
-                    </h4>    
-                </div>  
+                    </h4>
+                </div>
                 {{/if}}
+                
                 <div class="row">
                     <h4>
                         <div class="col-sm-1"><span class="label label-default">Metadata ID</span></div> 
-                        <div class="col-sm-7"><span>{{literal metadata.identifier.identifier}}</span></div>
-                    </h4>    
-                </div>  
+                        <div class="col-sm-7"><span title="{{metadata.identifier.type}}">{{literal metadata.identifier.identifier}}</span></div>
+                    </h4>
+                </div>
+                
                 {{#if metadata.description}}
                 <div class="row">
                     <h4>
                         <div class="col-sm-1"><span class="label label-default">Description</span></div> 
-                        <div class="col-sm-7"><span>{{literal metadata.description}}</span></div>    
-                    </h4>    
+                        <div class="col-sm-7"><p>{{literal metadata.description}}</p></div>    
+                    </h4>
                 </div>
                 {{/if}}
+                
                 <div class="row">
                     <h4>
                         <div class="col-sm-1"><span class="label label-default">Issued</span></div> 
                         <div class="col-sm-7"><span>{{literal metadata.issued}}</span></div> 
                     </h4>
-                </div>        
+                </div>
+                
                 <div class="row">
                     <h4>
                         <div class="col-sm-1"><span class="label label-default">Modified</span></div> 
                         <div class="col-sm-7"><span>{{literal metadata.modified}}</span></div>
                     </h4>
-                </div>    
+                </div>
+                
+                {{#if metadata.version}}
+                <div class="row">
+                    <h4>
+                        <div class="col-sm-1"><span class="label label-default">Version</span></div>
+                        <div class="col-sm-7"><span>{{literal metadata.version}}</span></div>
+                    </h4>
+                </div>
+                {{/if}}
+                
                 {{#if metadata.license}}
                 <div class="row">
                     <h4>
                         <div class="col-sm-1"><span class="label label-default">License</span></div>
-                        <div class="col-sm-7"><a target="_blank" href="{{metadata.license}}">license</a></div>
+                        <div class="col-sm-7"><a target="_blank" href="{{metadata.license}}">{{metadata.license}}</a></div>
                     </h4>
-                </div>    
+                </div>
                 {{/if}}
+                
+                {{#if metadata.rights}}
+                <div class="row">
+                    <h4>
+                        <div class="col-sm-1"><span class="label label-default">Rights</span></div>
+                        <div class="col-sm-7"><a target="_blank" href="{{metadata.rights}}">{{metadata.rights}}</a></div>
+                    </h4>
+                </div>
+                {{/if}}
+                
+                {{#if metadata.accessRights}}
+                <div class="row">
+                    <h4>
+                        <div class="col-sm-1"><span class="label label-default">Access Rights</span></div>
+                        <div class="col-sm-7"><p>{{literal metadata.accessRights.description}}</p></div>
+                    </h4>
+                </div>
+                {{/if}}
+                
+                {{#if metadata.specification}}
+                <div class="row">
+                    <h4>
+                        <div class="col-sm-1"><span class="label label-default">Specification</span></div>
+                        <div class="col-sm-7"><a target="_blank" href="{{metadata.specification}}">{{metadata.specification}}</a></div>
+                    </h4>
+                </div>
+                {{/if}}
+                
+                {{#if metadata.parentURI}}
+                <div class="row">
+                    <h4>
+                        <div class="col-sm-1"><span class="label label-default">Parent URI</span></div>
+                        <div class="col-sm-7"><a target="_blank" href="{{metadata.parentURI}}">{{metadata.parentURI}}</a></div>
+                    </h4>
+                </div>
+                {{/if}}
+                
+                {{#if metadata.language}}
+                <div class="row">
+                    <h4>
+                        <div class="col-sm-1"><span class="label label-default">Language</span></div>
+                        <div class="col-sm-7"><a target="_blank" href="{{metadata.language}}">{{metadata.language}}</a></div>
+                    </h4>
+                </div>
+                {{/if}}
+                
+                {{#if metadata.publisher}}
+                <div class="row">
+                    <h4>
+                        <div class="col-sm-1"><span class="label label-default">Publisher</span></div>
+                        <div class="col-sm-7"><a target="_blank" href="{{metadata.publisher.uri}}">{{literal metadata.publisher.name}}</a></div>
+                    </h4>
+                </div>
+                {{/if}}
+                
                 {{#block "content"}}
-                {{/block}}                
+                {{/block}}
+                      
                 {{#if metadata.uri}}
                 <div class="row">
                     <h4>
@@ -104,10 +174,10 @@
                             <a target="_blank" href="{{metadata.uri}}.jsonld">jsonld</a>
                         </div>
                     </h4>
-                </div>    
+                </div>
                 {{/if}}
-            </div>  
-        </div> 
+            </div>
+        </div>
         <footer class="footer">
             <div class="container">
                 <a href="https://www.dtls.nl/" target="_blank"><img class="pull-left" src="https://bioit.fair-dtls.surf-hosted.nl/dtllogo.png" width="135" height="45"></a>

--- a/src/main/webapp/WEB-INF/templates/catalog.hbs
+++ b/src/main/webapp/WEB-INF/templates/catalog.hbs
@@ -24,7 +24,23 @@
 </div>
 {{/if}}
 
+{{#if metadata.catalogIssued}}
+<div class="row">
+    <h4>
+        <div class="col-sm-1"><span class="label label-default">Catalog Issued</span></div>
+        <div class="col-sm-7"><span>{{literal metadata.catalogIssued}}</span></div>
+    </h4>
+</div>
+{{/if}}
 
+{{#if metadata.catalogModified}}
+<div class="row">
+    <h4>
+        <div class="col-sm-1"><span class="label label-default">Catalog Modified</span></div>
+        <div class="col-sm-7"><span>{{literal metadata.catalogModified}}</span></div>
+    </h4>
+</div>
+{{/if}}
 
 <div class="row">
     <h4>

--- a/src/main/webapp/WEB-INF/templates/dataset.hbs
+++ b/src/main/webapp/WEB-INF/templates/dataset.hbs
@@ -30,7 +30,7 @@
     <h4>
         <div class="col-sm-1"><span class="label label-default">Contact point</span></div>
          <div class="col-sm-7"><span><a target="_blank" href="{{metadata.contactPoint}}">{{metadata.contactPoint}}</a></span></div>
-    </h4>    
+    </h4>
 </div>  
 {{/if}}
 
@@ -39,8 +39,26 @@
     <h4>
         <div class="col-sm-1"><span class="label label-default">Landing page</span></div>
         <div class="col-sm-7"><span><a target="_blank" href="{{metadata.landingPage}}">{{metadata.landingPage}}</a></span></div>
-    </h4>    
+    </h4>
 </div>  
+{{/if}}
+
+{{#if metadata.datasetIssued}}
+<div class="row">
+    <h4>
+        <div class="col-sm-1"><span class="label label-default">Dataset Issued</span></div>
+        <div class="col-sm-7"><span>{{literal metadata.datasetIssued}}</span></div>
+    </h4>
+</div>
+{{/if}}
+
+{{#if metadata.datasetModified}}
+<div class="row">
+    <h4>
+        <div class="col-sm-1"><span class="label label-default">Dataset Modified</span></div>
+        <div class="col-sm-7"><span>{{literal metadata.datasetModified}}</span></div>
+    </h4>
+</div>
 {{/if}}
 
 <div class="row">

--- a/src/main/webapp/WEB-INF/templates/distribution.hbs
+++ b/src/main/webapp/WEB-INF/templates/distribution.hbs
@@ -1,6 +1,6 @@
 {{#partial "content"}}
 {{#if metadata.accessURL}}
-<div class="row">    
+<div class="row">
     <h4>
         <div class="col-sm-1"><span class="label label-default">Access url</span></div>
         <div class="col-sm-7"><span><a target="_blank" href="{{metadata.accessURL}}">{{metadata.accessURL}}</a></span></div>
@@ -8,8 +8,8 @@
 </div>
 {{/if}}
 
- {{#if metadata.downloadURL}}
-<div class="row"> 
+{{#if metadata.downloadURL}}
+<div class="row">
     <h4>
         <div class="col-sm-1"><span class="label label-default">Download url</span></div>
         <div class="col-sm-7"><span><a target="_blank" href="{{metadata.downloadURL}}">{{metadata.downloadURL}}</a></span></div>
@@ -18,10 +18,46 @@
 {{/if}}
 
 {{#if metadata.mediaType}}
-<div class="row">  
+<div class="row">
     <h4>
         <div class="col-sm-1"><span class="label label-default">MediaType</span></div>
         <div class="col-sm-7"><span>{{literal metadata.mediaType}}</span></div>
+    </h4>
+</div>
+{{/if}}
+
+{{#if metadata.format}}
+<div class="row">
+    <h4>
+        <div class="col-sm-1"><span class="label label-default">Format</span></div>
+        <div class="col-sm-7"><span>{{literal metadata.format}}</span></div>
+    </h4>
+</div>
+{{/if}}
+
+{{#if metadata.byteSize}}
+<div class="row">
+    <h4>
+        <div class="col-sm-1"><span class="label label-default">Bytesize</span></div>
+        <div class="col-sm-7"><span>{{literal metadata.byteSize}}</span></div>
+    </h4>
+</div>
+{{/if}}
+
+{{#if metadata.distributionIssued}}
+<div class="row">
+    <h4>
+        <div class="col-sm-1"><span class="label label-default">Distribution Issued</span></div>
+        <div class="col-sm-7"><span>{{literal metadata.distributionIssued}}</span></div>
+    </h4>
+</div>
+{{/if}}
+
+{{#if metadata.distributionModified}}
+<div class="row">
+    <h4>
+        <div class="col-sm-1"><span class="label label-default">Distribution Modified</span></div>
+        <div class="col-sm-7"><span>{{literal metadata.distributionModified}}</span></div>
     </h4>
 </div>
 {{/if}}

--- a/src/main/webapp/WEB-INF/templates/repository.hbs
+++ b/src/main/webapp/WEB-INF/templates/repository.hbs
@@ -1,5 +1,4 @@
 {{#partial "content"}}
-
 <div class="row">
     <h4>
         <div class="col-sm-1"><span class="label label-default">Catalogs</span></div>
@@ -10,6 +9,50 @@
         </div>
     </h4>
 </div>
-{{/partial}}
 
+{{#if metadata.repositoryIdentifier}}
+<div class="row">
+    <h4>
+        <div class="col-sm-1"><span class="label label-default">Repository Identifier</span></div>
+        <div class="col-sm-7"><span title="{{metadata.repositoryIdentifier.type}}">{{literal metadata.repositoryIdentifier.identifier}}</span></div>
+    </h4>
+</div>
+{{/if}}
+
+{{#if metadata.institutionCountry}}
+<div class="row">
+    <h4>
+        <div class="col-sm-1"><span class="label label-default">Institution Country</span></div>
+        <div class="col-sm-7"><a target="_blank" href="{{metadata.institutionCountry}}">{{metadata.institutionCountry}}</a></div>
+    </h4>
+</div>
+{{/if}}
+
+{{#if metadata.lastUpdate}}
+<div class="row">
+    <h4>
+        <div class="col-sm-1"><span class="label label-default">Last Update</span></div>
+        <div class="col-sm-7"><span>{{literal metadata.lastUpdate}}</span></div>
+    </h4>
+</div>
+{{/if}}
+
+{{#if metadata.startDate}}
+<div class="row">
+    <h4>
+        <div class="col-sm-1"><span class="label label-default">Start Date</span></div>
+        <div class="col-sm-7"><span>{{literal metadata.startDate}}</span></div>
+    </h4>
+</div>
+{{/if}}
+
+{{#if metadata.institution}}
+<div class="row">
+    <h4>
+        <div class="col-sm-1"><span class="label label-default">Institution</span></div>
+        <div class="col-sm-7"><a target="_blank" href="{{metadata.institution.uri}}">{{literal metadata.institution.name}}</a></div>
+    </h4>
+</div>
+{{/if}}
+{{/partial}}
 {{> base}}

--- a/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImplTest.java
+++ b/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImplTest.java
@@ -865,7 +865,7 @@ public class FairMetaDataServiceImplTest {
     public void retrieveNonExitingDatasetDistribution() throws
             FairMetadataServiceException {
         String uri = ExampleFilesUtils.DATASET_URI + "/dummpID676";
-       fairMetaDataService.retrieveDistributionMetaData(VALUEFACTORY.createIRI(uri));
+        fairMetaDataService.retrieveDistributionMetaData(VALUEFACTORY.createIRI(uri));
     }
 
     /**

--- a/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImplTest.java
+++ b/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImplTest.java
@@ -78,6 +78,8 @@ public class FairMetaDataServiceImplTest {
 
     private final static Logger LOGGER
             = LogManager.getLogger(FairMetaDataServiceImplTest.class.getName());
+    
+    private final static ValueFactory VALUEFACTORY = SimpleValueFactory.getInstance();
     @Autowired
     private FairMetaDataService fairMetaDataService;
     private final String TEST_FDP_URI = "http://example.com/fdp";
@@ -88,7 +90,6 @@ public class FairMetaDataServiceImplTest {
             = "http://example.com/fdp/catalog/dataset/datarecord";
     private final String TEST_DISTRIBUTION_URI
             = "http://example.com/fdp/catalog/dataset/distrubtion";
-    private final ValueFactory valueFactory = SimpleValueFactory.getInstance();
 
     @Before
     public void storeExampleMetadata() throws StoreManagerException,
@@ -156,8 +157,7 @@ public class FairMetaDataServiceImplTest {
         metadata.setIdentifier(null);
         try {
             fairMetaDataService.storeFDPMetaData(metadata);
-            FDPMetadata mdata = fairMetaDataService.retrieveFDPMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.FDP_URI));
+            FDPMetadata mdata = fairMetaDataService.retrieveFDPMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.FDP_URI));
             assertNotNull(mdata.getIdentifier());
         } catch (Exception ex) {
             fail("This test is not excepted to throw any error");
@@ -175,8 +175,7 @@ public class FairMetaDataServiceImplTest {
         metadata.setRepostoryIdentifier(null);
         try {
             fairMetaDataService.storeFDPMetaData(metadata);
-            FDPMetadata mdata = fairMetaDataService.retrieveFDPMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.FDP_URI));
+            FDPMetadata mdata = fairMetaDataService.retrieveFDPMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.FDP_URI));
             assertNotNull(mdata.getRepostoryIdentifier());
         } catch (Exception ex) {
             fail("This test is not excepted to throw any error");
@@ -194,8 +193,7 @@ public class FairMetaDataServiceImplTest {
         metadata.setPublisher(null);
         try {
             fairMetaDataService.storeFDPMetaData(metadata);
-            FDPMetadata mdata = fairMetaDataService.retrieveFDPMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.FDP_URI));
+            FDPMetadata mdata = fairMetaDataService.retrieveFDPMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.FDP_URI));
             assertNotNull(mdata.getPublisher());
         } catch (Exception ex) {
             fail("This test is not excepted to throw any error");
@@ -213,8 +211,7 @@ public class FairMetaDataServiceImplTest {
         metadata.setLanguage(null);
         try {
             fairMetaDataService.storeFDPMetaData(metadata);
-            FDPMetadata mdata = fairMetaDataService.retrieveFDPMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.FDP_URI));
+            FDPMetadata mdata = fairMetaDataService.retrieveFDPMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.FDP_URI));
             assertNotNull(mdata.getLanguage());
         } catch (Exception ex) {
             fail("This test is not excepted to throw any error");
@@ -232,8 +229,7 @@ public class FairMetaDataServiceImplTest {
         metadata.setLicense(null);
         try {
             fairMetaDataService.storeFDPMetaData(metadata);
-            FDPMetadata mdata = fairMetaDataService.retrieveFDPMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.FDP_URI));
+            FDPMetadata mdata = fairMetaDataService.retrieveFDPMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.FDP_URI));
             assertNotNull(mdata.getLicense());
         } catch (Exception ex) {
             fail("This test is not excepted to throw any error");
@@ -250,7 +246,7 @@ public class FairMetaDataServiceImplTest {
             FDPMetadata metadata = ExampleFilesUtils.getFDPMetadata(
                     TEST_FDP_URI);
             fairMetaDataService.storeFDPMetaData(metadata);
-            fairMetaDataService.updateFDPMetaData(valueFactory.
+            fairMetaDataService.updateFDPMetaData(VALUEFACTORY.
                     createIRI(TEST_FDP_URI), metadata);
         } catch (FairMetadataServiceException | MetadataException ex) {
             fail("This test is not expected to throw an errors");
@@ -277,8 +273,7 @@ public class FairMetaDataServiceImplTest {
     @DirtiesContext
     @Test
     public void retrieveFDPMetaData() throws FairMetadataServiceException {
-        assertNotNull(fairMetaDataService.retrieveFDPMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.FDP_URI)));
+        assertNotNull(fairMetaDataService.retrieveFDPMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.FDP_URI)));
     }     
     
     /**
@@ -291,8 +286,7 @@ public class FairMetaDataServiceImplTest {
     @Test
     public void existenceFDPMetaDataSpecsLink() throws 
             FairMetadataServiceException, MetadataException {
-        FDPMetadata metadata = fairMetaDataService.retrieveFDPMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.FDP_URI));
+        FDPMetadata metadata = fairMetaDataService.retrieveFDPMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.FDP_URI));
         assertNotNull(metadata.getSpecification());
     }
     
@@ -314,7 +308,7 @@ public class FairMetaDataServiceImplTest {
         // Store a catalog metadata
         fairMetaDataService.storeCatalogMetaData(ExampleFilesUtils.getCatalogMetadata(
                 "http://www.example.com/cat1", ExampleFilesUtils.FDP_URI));
-        FDPMetadata metadata = fairMetaDataService.retrieveFDPMetaData(valueFactory.createIRI(
+        FDPMetadata metadata = fairMetaDataService.retrieveFDPMetaData(VALUEFACTORY.createIRI(
                 "http://www.example.com/cat1"));
         assertFalse(metadata.getMetrics().isEmpty());
     }
@@ -325,7 +319,7 @@ public class FairMetaDataServiceImplTest {
     @DirtiesContext
     @Test
     public void existenceAccessRightsStatement() throws Exception {
-        FDPMetadata metadata = fairMetaDataService.retrieveFDPMetaData(valueFactory.createIRI(
+        FDPMetadata metadata = fairMetaDataService.retrieveFDPMetaData(VALUEFACTORY.createIRI(
                 ExampleFilesUtils.FDP_URI));
         assertNotNull(metadata.getAccessRights().getDescription());
     }
@@ -374,8 +368,7 @@ public class FairMetaDataServiceImplTest {
         metadata.setIdentifier(null);
         try {
             fairMetaDataService.storeCatalogMetaData(metadata);
-            CatalogMetadata mdata = fairMetaDataService.retrieveCatalogMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.CATALOG_URI));
+            CatalogMetadata mdata = fairMetaDataService.retrieveCatalogMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.CATALOG_URI));
             assertNotNull(mdata.getIdentifier());
         } catch (Exception ex) {
             fail("This test is not excepted to throw any error");
@@ -394,8 +387,7 @@ public class FairMetaDataServiceImplTest {
         metadata.setPublisher(null);
         try {
             fairMetaDataService.storeCatalogMetaData(metadata);
-            CatalogMetadata mdata = fairMetaDataService.retrieveCatalogMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.CATALOG_URI));
+            CatalogMetadata mdata = fairMetaDataService.retrieveCatalogMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.CATALOG_URI));
             assertNotNull(mdata.getPublisher());
         } catch (Exception ex) {
             fail("This test is not excepted to throw any error");
@@ -414,8 +406,7 @@ public class FairMetaDataServiceImplTest {
         metadata.setLanguage(null);
         try {
             fairMetaDataService.storeCatalogMetaData(metadata);
-            CatalogMetadata mdata = fairMetaDataService.retrieveCatalogMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.CATALOG_URI));
+            CatalogMetadata mdata = fairMetaDataService.retrieveCatalogMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.CATALOG_URI));
             assertNotNull(mdata.getLanguage());
         } catch (Exception ex) {
             fail("This test is not excepted to throw any error");
@@ -434,8 +425,7 @@ public class FairMetaDataServiceImplTest {
         metadata.setLicense(null);
         try {
             fairMetaDataService.storeCatalogMetaData(metadata);
-            CatalogMetadata mdata = fairMetaDataService.retrieveCatalogMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.CATALOG_URI));
+            CatalogMetadata mdata = fairMetaDataService.retrieveCatalogMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.CATALOG_URI));
             assertNotNull(mdata.getLicense());
         } catch (Exception ex) {
             fail("This test is not excepted to throw any error");
@@ -453,8 +443,7 @@ public class FairMetaDataServiceImplTest {
     public void retrieveNonExitingCatalogMetaData() throws
             FairMetadataServiceException {
         String uri = ExampleFilesUtils.FDP_URI + "/dummpID676";
-        fairMetaDataService.retrieveCatalogMetaData(
-                valueFactory.createIRI(uri));
+        fairMetaDataService.retrieveCatalogMetaData(VALUEFACTORY.createIRI(uri));
     }
 
     /**
@@ -465,8 +454,7 @@ public class FairMetaDataServiceImplTest {
     @DirtiesContext
     @Test
     public void retrieveCatalogMetaData() throws FairMetadataServiceException {
-        assertNotNull(fairMetaDataService.retrieveCatalogMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.CATALOG_URI)));
+        assertNotNull(fairMetaDataService.retrieveCatalogMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.CATALOG_URI)));
     }
     
     /**
@@ -479,8 +467,7 @@ public class FairMetaDataServiceImplTest {
     @Test
     public void existenceCatalogMetaDataSpecsLink() throws 
             FairMetadataServiceException, MetadataException {
-        CatalogMetadata metadata = fairMetaDataService.retrieveCatalogMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.CATALOG_URI));
+        CatalogMetadata metadata = fairMetaDataService.retrieveCatalogMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.CATALOG_URI));
         assertNotNull(metadata.getSpecification());
     }
 
@@ -543,8 +530,7 @@ public class FairMetaDataServiceImplTest {
         metadata.setIdentifier(null);
         try {
             fairMetaDataService.storeDatasetMetaData(metadata);
-            DatasetMetadata mdata = fairMetaDataService.retrieveDatasetMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.DATASET_URI));
+            DatasetMetadata mdata = fairMetaDataService.retrieveDatasetMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.DATASET_URI));
             assertNotNull(mdata.getIdentifier());
         } catch (Exception ex) {
             fail("This test is not excepted to throw any error");
@@ -563,8 +549,7 @@ public class FairMetaDataServiceImplTest {
         metadata.setPublisher(null);
         try {
             fairMetaDataService.storeDatasetMetaData(metadata);
-            DatasetMetadata mdata = fairMetaDataService.retrieveDatasetMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.DATASET_URI));
+            DatasetMetadata mdata = fairMetaDataService.retrieveDatasetMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.DATASET_URI));
             assertNotNull(mdata.getPublisher());
         } catch (Exception ex) {
             fail("This test is not excepted to throw any error");
@@ -583,8 +568,7 @@ public class FairMetaDataServiceImplTest {
         metadata.setLanguage(null);
         try {
             fairMetaDataService.storeDatasetMetaData(metadata);
-            DatasetMetadata mdata = fairMetaDataService.retrieveDatasetMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.DATASET_URI));
+            DatasetMetadata mdata = fairMetaDataService.retrieveDatasetMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.DATASET_URI));
             assertNotNull(mdata.getLanguage());
         } catch (Exception ex) {
             fail("This test is not excepted to throw any error");
@@ -603,8 +587,7 @@ public class FairMetaDataServiceImplTest {
         metadata.setLicense(null);
         try {
             fairMetaDataService.storeDatasetMetaData(metadata);
-            DatasetMetadata mdata = fairMetaDataService.retrieveDatasetMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.DATASET_URI));
+            DatasetMetadata mdata = fairMetaDataService.retrieveDatasetMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.DATASET_URI));
             assertNotNull(mdata.getLicense());
         } catch (Exception ex) {
             fail("This test is not excepted to throw any error");
@@ -622,8 +605,7 @@ public class FairMetaDataServiceImplTest {
     public void retrieveNonExitingdDatasetMetaData() throws
             FairMetadataServiceException {
         String uri = ExampleFilesUtils.CATALOG_URI + "/dummpID676";
-        fairMetaDataService.retrieveDatasetMetaData(
-                valueFactory.createIRI(uri));
+        fairMetaDataService.retrieveDatasetMetaData(VALUEFACTORY.createIRI(uri));
     }
 
     /**
@@ -634,8 +616,7 @@ public class FairMetaDataServiceImplTest {
     @DirtiesContext
     @Test
     public void retrieveDatasetMetaData() throws FairMetadataServiceException {
-        assertNotNull(fairMetaDataService.retrieveDatasetMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.DATASET_URI)));
+        assertNotNull(fairMetaDataService.retrieveDatasetMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.DATASET_URI)));
     }
     
     /**
@@ -648,8 +629,7 @@ public class FairMetaDataServiceImplTest {
     @Test
     public void existenceDatasetMetaDataSpecsLink() throws 
             FairMetadataServiceException, MetadataException {
-        DatasetMetadata metadata = fairMetaDataService.retrieveDatasetMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.DATASET_URI));
+        DatasetMetadata metadata = fairMetaDataService.retrieveDatasetMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.DATASET_URI));
         assertNotNull(metadata.getSpecification());
     }
 
@@ -712,7 +692,7 @@ public class FairMetaDataServiceImplTest {
         try {
             fairMetaDataService.storeDistributionMetaData(metadata);
             DistributionMetadata mdata = fairMetaDataService.
-                    retrieveDistributionMetaData(valueFactory.createIRI(
+                    retrieveDistributionMetaData(VALUEFACTORY.createIRI(
                             ExampleFilesUtils.DISTRIBUTION_URI));
             assertNotNull(mdata.getIdentifier());
         } catch (Exception ex) {
@@ -733,7 +713,7 @@ public class FairMetaDataServiceImplTest {
         try {
             fairMetaDataService.storeDistributionMetaData(metadata);
             DistributionMetadata mdata = fairMetaDataService.
-                    retrieveDistributionMetaData(valueFactory.createIRI(
+                    retrieveDistributionMetaData(VALUEFACTORY.createIRI(
                             ExampleFilesUtils.DISTRIBUTION_URI));
             assertNotNull(mdata.getPublisher());
         } catch (Exception ex) {
@@ -755,7 +735,7 @@ public class FairMetaDataServiceImplTest {
         try {
             fairMetaDataService.storeDistributionMetaData(metadata);
             DistributionMetadata mdata = fairMetaDataService.
-                    retrieveDistributionMetaData(valueFactory.createIRI(
+                    retrieveDistributionMetaData(VALUEFACTORY.createIRI(
                             ExampleFilesUtils.DISTRIBUTION_URI));
             assertNotNull(mdata.getLicense());
         } catch (Exception ex) {
@@ -776,7 +756,7 @@ public class FairMetaDataServiceImplTest {
         try {
             fairMetaDataService.storeDistributionMetaData(metadata);
             DistributionMetadata mdata = fairMetaDataService.
-                    retrieveDistributionMetaData(valueFactory.createIRI(
+                    retrieveDistributionMetaData(VALUEFACTORY.createIRI(
                             ExampleFilesUtils.DISTRIBUTION_URI));
             assertNotNull(mdata.getLanguage());
         } catch (Exception ex) {
@@ -845,7 +825,7 @@ public class FairMetaDataServiceImplTest {
         try {
             fairMetaDataService.storeDataRecordMetaData(metadata);
             DataRecordMetadata mdata = fairMetaDataService.
-                    retrieveDataRecordMetadata(valueFactory.createIRI(
+                    retrieveDataRecordMetadata(VALUEFACTORY.createIRI(
                             TEST_DATARECORD_URI));
             assertNotNull(mdata.getIdentifier());
         } catch (Exception ex) {
@@ -866,7 +846,7 @@ public class FairMetaDataServiceImplTest {
         try {
             fairMetaDataService.storeDataRecordMetaData(metadata);
             DataRecordMetadata mdata = fairMetaDataService.
-                    retrieveDataRecordMetadata(valueFactory.createIRI(
+                    retrieveDataRecordMetadata(VALUEFACTORY.createIRI(
                             TEST_DATARECORD_URI));
             assertNotNull(mdata.getPublisher());
         } catch (Exception ex) {
@@ -885,8 +865,7 @@ public class FairMetaDataServiceImplTest {
     public void retrieveNonExitingDatasetDistribution() throws
             FairMetadataServiceException {
         String uri = ExampleFilesUtils.DATASET_URI + "/dummpID676";
-       fairMetaDataService.retrieveDistributionMetaData(
-                valueFactory.createIRI(uri));
+       fairMetaDataService.retrieveDistributionMetaData(VALUEFACTORY.createIRI(uri));
     }
 
     /**
@@ -898,8 +877,7 @@ public class FairMetaDataServiceImplTest {
     @Test
     public void retrieveDatasetDistribution() throws
             FairMetadataServiceException {
-        assertNotNull(fairMetaDataService.retrieveDistributionMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.DISTRIBUTION_URI)));
+        assertNotNull(fairMetaDataService.retrieveDistributionMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.DISTRIBUTION_URI)));
     }
     
     /**
@@ -913,8 +891,7 @@ public class FairMetaDataServiceImplTest {
     public void existenceDistributionMetaDataSpecsLink() throws 
             FairMetadataServiceException, MetadataException {
         DistributionMetadata metadata = fairMetaDataService.
-                retrieveDistributionMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.DISTRIBUTION_URI));
+                retrieveDistributionMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.DISTRIBUTION_URI));
         assertNotNull(metadata.getSpecification());
     }
     
@@ -924,21 +901,19 @@ public class FairMetaDataServiceImplTest {
         // given
         DistributionMetadata newDistribution = ExampleFilesUtils.getDistributionMetadata(
                 TEST_DISTRIBUTION_URI, ExampleFilesUtils.DATASET_URI);
-        newDistribution.setByteSize(valueFactory.createLiteral(1_000L));
+        newDistribution.setByteSize(VALUEFACTORY.createLiteral(1_000L));
         
         // when
         fairMetaDataService.storeDistributionMetaData(newDistribution);
         
         // then
-        newDistribution = fairMetaDataService.retrieveDistributionMetaData(
-                valueFactory.createIRI(TEST_DISTRIBUTION_URI));
+        newDistribution = fairMetaDataService.retrieveDistributionMetaData(VALUEFACTORY.createIRI(TEST_DISTRIBUTION_URI));
         ZonedDateTime distributionModified = ZonedDateTime.parse(
                 newDistribution.getModified().stringValue());
         
         // compare dataset timestamp with distribution timestamp
         {
-            DatasetMetadata updated = fairMetaDataService.retrieveDatasetMetaData(
-                    valueFactory.createIRI(ExampleFilesUtils.DATASET_URI));
+            DatasetMetadata updated = fairMetaDataService.retrieveDatasetMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.DATASET_URI));
             ZonedDateTime updatedModified = ZonedDateTime.parse(
                     updated.getModified().stringValue());
             assertTrue("Distribution is modified before the dataset is modified",
@@ -946,8 +921,7 @@ public class FairMetaDataServiceImplTest {
         }
         // compare catalog timestamp with distribution timestamp
         {
-            CatalogMetadata updated = fairMetaDataService.retrieveCatalogMetaData(
-                    valueFactory.createIRI(ExampleFilesUtils.CATALOG_URI));
+            CatalogMetadata updated = fairMetaDataService.retrieveCatalogMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.CATALOG_URI));
             ZonedDateTime updatedModified = ZonedDateTime.parse(
                     updated.getModified().stringValue());
             assertTrue("Distribution is modified before the catalog is modified",
@@ -955,8 +929,7 @@ public class FairMetaDataServiceImplTest {
         }
         // compare repository timestamp with distribution timestamp
         {
-            FDPMetadata updated = fairMetaDataService.retrieveFDPMetaData(
-                    valueFactory.createIRI(ExampleFilesUtils.FDP_URI));
+            FDPMetadata updated = fairMetaDataService.retrieveFDPMetaData(VALUEFACTORY.createIRI(ExampleFilesUtils.FDP_URI));
             ZonedDateTime updatedModified = ZonedDateTime.parse(
                     updated.getModified().stringValue());
             assertTrue("Distribution is modified before the repository is modified",

--- a/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImplTest.java
+++ b/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImplTest.java
@@ -320,17 +320,13 @@ public class FairMetaDataServiceImplTest {
     }
     
     /**
-     * Test existence of access rigghts
-     *
-     * @throws nl.dtls.fairdatapoint.service.FairMetadataServiceException
-     * @throws nl.dtl.fairmetadata4j.io.MetadataException
+     * Test existence of access rights description
      */
     @DirtiesContext
     @Test
-    public void existenceAccessRightsStatement() throws 
-            FairMetadataServiceException, MetadataException {
-        FDPMetadata metadata = fairMetaDataService.retrieveFDPMetaData(
-                valueFactory.createIRI(ExampleFilesUtils.FDP_URI));
+    public void existenceAccessRightsStatement() throws Exception {
+        FDPMetadata metadata = fairMetaDataService.retrieveFDPMetaData(valueFactory.createIRI(
+                ExampleFilesUtils.FDP_URI));
         assertNotNull(metadata.getAccessRights().getDescription());
     }
 

--- a/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImplTest.java
+++ b/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImplTest.java
@@ -318,6 +318,21 @@ public class FairMetaDataServiceImplTest {
                 "http://www.example.com/cat1"));
         assertFalse(metadata.getMetrics().isEmpty());
     }
+    
+    /**
+     * Test existence of access rigghts
+     *
+     * @throws nl.dtls.fairdatapoint.service.FairMetadataServiceException
+     * @throws nl.dtl.fairmetadata4j.io.MetadataException
+     */
+    @DirtiesContext
+    @Test
+    public void existenceAccessRightsStatement() throws 
+            FairMetadataServiceException, MetadataException {
+        FDPMetadata metadata = fairMetaDataService.retrieveFDPMetaData(
+                valueFactory.createIRI(ExampleFilesUtils.FDP_URI));
+        assertNotNull(metadata.getAccessRights().getDescription());
+    }
 
     /**
      * Test to store catalog metadata, this test is excepted to throw error


### PR DESCRIPTION
I modified the addDefaultValues method in the FairMetaDataServiceImpl service layer to add default access rights.  In the current implementation the metadata content has no access restriction at all.  