### PR TITLE
External triple store support 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-                
+        <maven.compiler.target>1.8</maven.compiler.target>                
         <springframework.version>5.0.0.RELEASE</springframework.version>
         <springdata.version>3.0.0.RELEASE</springdata.version>        
         <springfox-swagger.version>2.6.1</springfox-swagger.version>        
@@ -52,8 +51,7 @@
         <snakeyaml.version>1.19</snakeyaml.version>        
         <unirest.version>1.4.9</unirest.version>
         <junit.version>4.12</junit.version>
-        <mockito.version>2.11.0</mockito.version>
-        
+        <mockito.version>2.11.0</mockito.version>        
         <plugin.mavenwar.version>3.2.0</plugin.mavenwar.version>
         <plugin.mavenlic.version>3.0</plugin.mavenlic.version>
         <plugin.coveralls.version>4.3.0</plugin.coveralls.version>
@@ -74,7 +72,7 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
             <version>${springframework.version}</version>
-        </dependency>
+        </dependency>        
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-rest-webmvc</artifactId>

--- a/src/main/java/nl/dtls/fairdatapoint/api/config/RestApiContext.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/config/RestApiContext.java
@@ -186,7 +186,7 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
             repository = new SailRepository(new NativeStore(dataDir));
         }
         // In memory is the default store
-        if (storeType == 3 || repository == null) {
+        if (storeType == 1 || repository == null) {
             Sail store = new MemoryStore();
             repository = new SailRepository(store);
             LOGGER.info("Initializing inmemory store");

--- a/src/main/java/nl/dtls/fairdatapoint/api/config/RestApiContext.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/config/RestApiContext.java
@@ -22,7 +22,6 @@
  */
 package nl.dtls.fairdatapoint.api.config;
 
-
 import static org.eclipse.rdf4j.rio.RDFFormat.TURTLE;
 import java.io.IOException;
 import java.util.List;
@@ -64,6 +63,8 @@ import nl.dtls.fairdatapoint.repository.impl.StoreManagerImpl;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.repository.manager.RemoteRepositoryManager;
+import org.eclipse.rdf4j.repository.manager.RepositoryManager;
 import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,6 +94,30 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
 
     private final ValueFactory valueFactory = SimpleValueFactory.getInstance();
 
+    @org.springframework.beans.factory.annotation.Value("${store.native.dir:nil}")
+    private String nativeStoreDir;
+
+    @org.springframework.beans.factory.annotation.Value("${store.agraph.url:nil}")
+    private String agraphUrl;
+
+    @org.springframework.beans.factory.annotation.Value("${store.agraph.username:nil}")
+    private String agraphUsername;
+
+    @org.springframework.beans.factory.annotation.Value("${store.agraph.password:nil}")
+    private String agraphPassword;
+
+    @org.springframework.beans.factory.annotation.Value("${store.graphDb.url:nil}")
+    private String graphDbUrl;
+
+    @org.springframework.beans.factory.annotation.Value("${store.graphDb.repository:nil}")
+    private String graphDbRepository;
+
+    @org.springframework.beans.factory.annotation.Value("${store.blazegraph.url:nil}")
+    private String blazegraphUrl;
+
+    @org.springframework.beans.factory.annotation.Value("${store.blazegraph.repository:nil}")
+    private String blazegraphRepository;
+
     @Override
     public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
         converters.addAll(metadataConverters);
@@ -105,8 +130,8 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
             converter.configureContentNegotiation(configurer);
         }
     }
-    
-    @Bean( destroyMethod = "shutdownNow")
+
+    @Bean(destroyMethod = "shutdownNow")
     public Executor threadPoolTaskExecutor(@Value("${threadPoolSize:4}") int threadPoolSize) {
         return Executors.newFixedThreadPool(threadPoolSize);
     }
@@ -114,9 +139,9 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
     @Bean(name = "publisher")
     public Agent publisher(@Value("${metadataProperties.publisherURI:nil}") String publisherURI,
             @Value("${metadataProperties.publisherName:nil}") String publishername) {
+        
         Agent publisher = null;
-        if (!publisherURI.contentEquals("nil")
-                && !publishername.contentEquals("nil")) {
+        if (!publisherURI.contentEquals("nil") && !publishername.contentEquals("nil")) {
             publisher = new Agent();
             publisher.setUri(valueFactory.createIRI(publisherURI));
             publisher.setName(valueFactory.createLiteral(publishername));
@@ -126,6 +151,7 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
 
     @Bean(name = "language")
     public IRI language(@Value("${metadataProperties.language:nil}") String languageURI) {
+        
         IRI language = null;
         if (!languageURI.contentEquals("nil")) {
             language = valueFactory.createIRI(languageURI);
@@ -135,6 +161,7 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
 
     @Bean(name = "license")
     public IRI license(@Value("${metadataProperties.license:nil}") String licenseURI) {
+        
         IRI license = null;
         if (!licenseURI.contentEquals("nil")) {
             license = valueFactory.createIRI(licenseURI);
@@ -142,27 +169,24 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
         return license;
     }
 
-    @Bean(name = "repository", initMethod = "initialize",
-            destroyMethod = "shutDown")
-    public Repository repository(@Value("${store.type:1}") int storeType,
-            @Value("${store.url}") String storeUrl,
-            @Value("${store.username:nil}") String storeUsername,
-            @Value("${store.password:nil}") String storeUserPassword,
-            @Value("${store.dir:}") String storeDir)
+    @Bean(name = "repository", initMethod = "initialize", destroyMethod = "shutDown")
+    public Repository repository(@Value("${store.type:1}") int storeType)
             throws RepositoryException {
-        Repository repository;
-        if (storeType == 1 && !storeUsername.isEmpty()
-                && !storeUsername.contains("nil")) { // HTTP endpoint
-            SPARQLRepository sRepository = new SPARQLRepository(storeUrl);
-            LOGGER.info("Initializing HTTP triple store ");
-            sRepository.setUsernameAndPassword(storeUsername,
-                    storeUserPassword);
-            return sRepository;
-        } else if (storeType == 2 && !storeDir.isEmpty()) {
-            File dataDir = new File(storeDir);
+        
+        Repository repository = null;
+        if (storeType == 3) { // Allegrograph as a backend store
+            repository = getAgraphRepository();
+        } else if (storeType == 4) { // GraphDB as a backend store
+            repository = getGraphRepository();
+        } else if (storeType == 5) {    // Blazegraph as a backend store
+            repository = getBlazeGraphRepository();
+        } else if (storeType == 2 && !nativeStoreDir.contains("nil")) { // Native store
+            File dataDir = new File(nativeStoreDir);
             LOGGER.info("Initializing native store");
             repository = new SailRepository(new NativeStore(dataDir));
-        } else { // In memory is the default store
+        }
+        // In memory is the default store
+        if (storeType == 3 || repository == null) {
             Sail store = new MemoryStore();
             repository = new SailRepository(store);
             LOGGER.info("Initializing inmemory store");
@@ -170,17 +194,80 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
         return repository;
     }
 
+    /**
+     * Get allegrograph repository
+     *
+     * @return SPARQLRepository
+     */
+    private Repository getAgraphRepository() {
+
+        SPARQLRepository sRepository = null;
+        if (!agraphUrl.contains("nil")) {
+            LOGGER.info("Initializing allegrograph repository");
+            sRepository = new SPARQLRepository(agraphUrl);
+            if (!agraphUsername.contains("nil") && !agraphPassword.contains("nil")) {
+                sRepository.setUsernameAndPassword(agraphUsername, agraphPassword);
+            }
+        }
+        return sRepository;
+    }
+
+    /**
+     * Get blazegraph repository
+     *
+     * @return SPARQLRepository
+     */
+    private Repository getBlazeGraphRepository() {
+
+        SPARQLRepository sRepository = null;
+        if (!blazegraphUrl.contains("nil")) {
+            LOGGER.info("Initializing blazegraph repository");
+            if (blazegraphUrl.endsWith("/")) {
+                blazegraphUrl = blazegraphUrl.substring(0, blazegraphUrl.length() - 1);
+            }
+            // Build url for blazegraph (Eg: http://localhost:8079/bigdata/namespace/test1/sparql)
+            StringBuilder sb = new StringBuilder();
+            sb.append(blazegraphUrl);
+            sb.append("/namespace/");
+            if (!blazegraphRepository.contains("nil")) {
+                sb.append(blazegraphRepository);
+            } else {
+                sb.append("kb");
+            }
+            sb.append("/sparql");
+            String url = sb.toString();
+            sRepository = new SPARQLRepository(url);
+        }
+        return sRepository;
+    }
+
+    /**
+     * Get graphDB repository
+     *
+     * @return Repository
+     */
+    private Repository getGraphRepository() {
+
+        Repository repository = null;
+        if (!graphDbUrl.contains("nil") && !graphDbRepository.contains("nil")) {
+            LOGGER.info("Initializing graphDB repository");
+            RepositoryManager repositoryManager = new RemoteRepositoryManager(graphDbUrl);
+            repositoryManager.initialize();
+            repository = repositoryManager.getRepository(graphDbRepository);
+        }
+        return repository;
+    }
+
     @Bean(name = "storeManager")
     @DependsOn({"repository"})
-    public StoreManager storeManager() throws RepositoryException,
-            StoreManagerException {
+    public StoreManager storeManager() throws RepositoryException, StoreManagerException {
         return new StoreManagerImpl();
     }
 
     @Override
     public void addResourceHandlers(final ResourceHandlerRegistry registry) {
-        registry.setOrder(Integer.MIN_VALUE + 1).
-                addResourceHandler("/swagger-ui.html")
+        
+        registry.setOrder(Integer.MIN_VALUE + 1).addResourceHandler("/swagger-ui.html")
                 .addResourceLocations("classpath:/META-INF/resources/");
 
         registry.setOrder(Integer.MIN_VALUE + 2).
@@ -189,8 +276,7 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
     }
 
     @Override
-    public void configureDefaultServletHandling(
-            final DefaultServletHandlerConfigurer configurer) {
+    public void configureDefaultServletHandling(final DefaultServletHandlerConfigurer configurer) {
         configurer.enable();
     }
 
@@ -201,6 +287,7 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
 
     @Bean
     public ViewResolver handlebars() {
+        
         HandlebarsViewResolver viewResolver = new HandlebarsViewResolver();
 
         // add handlebars helper to get a label's literal without datatype

--- a/src/main/java/nl/dtls/fairdatapoint/api/config/RestApiContext.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/config/RestApiContext.java
@@ -94,28 +94,28 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
 
     private final ValueFactory valueFactory = SimpleValueFactory.getInstance();
 
-    @org.springframework.beans.factory.annotation.Value("${store.native.dir:nil}")
+    @Value("${store.native.dir:nil}")
     private String nativeStoreDir;
 
-    @org.springframework.beans.factory.annotation.Value("${store.agraph.url:nil}")
+    @Value("${store.agraph.url:nil}")
     private String agraphUrl;
 
-    @org.springframework.beans.factory.annotation.Value("${store.agraph.username:nil}")
+    @Value("${store.agraph.username:nil}")
     private String agraphUsername;
 
-    @org.springframework.beans.factory.annotation.Value("${store.agraph.password:nil}")
+    @Value("${store.agraph.password:nil}")
     private String agraphPassword;
 
-    @org.springframework.beans.factory.annotation.Value("${store.graphDb.url:nil}")
+    @Value("${store.graphDb.url:nil}")
     private String graphDbUrl;
 
-    @org.springframework.beans.factory.annotation.Value("${store.graphDb.repository:nil}")
+    @Value("${store.graphDb.repository:nil}")
     private String graphDbRepository;
 
-    @org.springframework.beans.factory.annotation.Value("${store.blazegraph.url:nil}")
+    @Value("${store.blazegraph.url:nil}")
     private String blazegraphUrl;
 
-    @org.springframework.beans.factory.annotation.Value("${store.blazegraph.repository:nil}")
+    @Value("${store.blazegraph.repository:nil}")
     private String blazegraphRepository;
 
     @Override

--- a/src/main/java/nl/dtls/fairdatapoint/api/config/RestApiContext.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/config/RestApiContext.java
@@ -92,30 +92,30 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
     @Autowired
     private List<AbstractMetadataMessageConverter<?>> metadataConverters;
 
-    private final ValueFactory valueFactory = SimpleValueFactory.getInstance();
+    private final ValueFactory VALUEFACTORY = SimpleValueFactory.getInstance();
 
-    @Value("${store.native.dir:nil}")
+    @Value("${store.native.dir:}")
     private String nativeStoreDir;
 
-    @Value("${store.agraph.url:nil}")
+    @Value("${store.agraph.url:}")
     private String agraphUrl;
 
-    @Value("${store.agraph.username:nil}")
+    @Value("${store.agraph.username:}")
     private String agraphUsername;
 
-    @Value("${store.agraph.password:nil}")
+    @Value("${store.agraph.password:}")
     private String agraphPassword;
 
-    @Value("${store.graphDb.url:nil}")
+    @Value("${store.graphDb.url:}")
     private String graphDbUrl;
 
-    @Value("${store.graphDb.repository:nil}")
+    @Value("${store.graphDb.repository:}")
     private String graphDbRepository;
 
-    @Value("${store.blazegraph.url:nil}")
+    @Value("${store.blazegraph.url:}")
     private String blazegraphUrl;
 
-    @Value("${store.blazegraph.repository:nil}")
+    @Value("${store.blazegraph.repository:}")
     private String blazegraphRepository;
 
     @Override
@@ -137,34 +137,34 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
     }
 
     @Bean(name = "publisher")
-    public Agent publisher(@Value("${metadataProperties.publisherURI:nil}") String publisherURI,
-            @Value("${metadataProperties.publisherName:nil}") String publishername) {
+    public Agent publisher(@Value("${metadataProperties.publisherURI:}") String publisherURI,
+            @Value("${metadataProperties.publisherName:}") String publishername) {
         
         Agent publisher = null;
-        if (!publisherURI.contentEquals("nil") && !publishername.contentEquals("nil")) {
+        if (!publisherURI.isEmpty() && !publishername.isEmpty()) {
             publisher = new Agent();
-            publisher.setUri(valueFactory.createIRI(publisherURI));
-            publisher.setName(valueFactory.createLiteral(publishername));
+            publisher.setUri(VALUEFACTORY.createIRI(publisherURI));
+            publisher.setName(VALUEFACTORY.createLiteral(publishername));
         }
         return publisher;
     }
 
     @Bean(name = "language")
-    public IRI language(@Value("${metadataProperties.language:nil}") String languageURI) {
+    public IRI language(@Value("${metadataProperties.language:}") String languageURI) {
         
         IRI language = null;
-        if (!languageURI.contentEquals("nil")) {
-            language = valueFactory.createIRI(languageURI);
+        if (!languageURI.isEmpty()) {
+            language = VALUEFACTORY.createIRI(languageURI);
         }
         return language;
     }
 
     @Bean(name = "license")
-    public IRI license(@Value("${metadataProperties.license:nil}") String licenseURI) {
+    public IRI license(@Value("${metadataProperties.license:}") String licenseURI) {
         
         IRI license = null;
-        if (!licenseURI.contentEquals("nil")) {
-            license = valueFactory.createIRI(licenseURI);
+        if (!licenseURI.isEmpty()) {
+            license = VALUEFACTORY.createIRI(licenseURI);
         }
         return license;
     }
@@ -180,7 +180,7 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
             repository = getGraphRepository();
         } else if (storeType == 5) {    // Blazegraph as a backend store
             repository = getBlazeGraphRepository();
-        } else if (storeType == 2 && !nativeStoreDir.contains("nil")) { // Native store
+        } else if (storeType == 2 && !nativeStoreDir.isEmpty()) { // Native store
             File dataDir = new File(nativeStoreDir);
             LOGGER.info("Initializing native store");
             repository = new SailRepository(new NativeStore(dataDir));
@@ -202,10 +202,10 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
     private Repository getAgraphRepository() {
 
         SPARQLRepository sRepository = null;
-        if (!agraphUrl.contains("nil")) {
+        if (!agraphUrl.isEmpty()) {
             LOGGER.info("Initializing allegrograph repository");
             sRepository = new SPARQLRepository(agraphUrl);
-            if (!agraphUsername.contains("nil") && !agraphPassword.contains("nil")) {
+            if (!agraphUsername.isEmpty() && !agraphPassword.isEmpty()) {
                 sRepository.setUsernameAndPassword(agraphUsername, agraphPassword);
             }
         }
@@ -220,7 +220,7 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
     private Repository getBlazeGraphRepository() {
 
         SPARQLRepository sRepository = null;
-        if (!blazegraphUrl.contains("nil")) {
+        if (!blazegraphUrl.isEmpty()) {
             LOGGER.info("Initializing blazegraph repository");
             if (blazegraphUrl.endsWith("/")) {
                 blazegraphUrl = blazegraphUrl.substring(0, blazegraphUrl.length() - 1);
@@ -229,7 +229,7 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
             StringBuilder sb = new StringBuilder();
             sb.append(blazegraphUrl);
             sb.append("/namespace/");
-            if (!blazegraphRepository.contains("nil")) {
+            if (!blazegraphRepository.isEmpty()) {
                 sb.append(blazegraphRepository);
             } else {
                 sb.append("kb");
@@ -249,7 +249,7 @@ public class RestApiContext extends WebMvcConfigurerAdapter {
     private Repository getGraphRepository() {
 
         Repository repository = null;
-        if (!graphDbUrl.contains("nil") && !graphDbRepository.contains("nil")) {
+        if (!graphDbUrl.isEmpty() && !graphDbRepository.isEmpty()) {
             LOGGER.info("Initializing graphDB repository");
             RepositoryManager repositoryManager = new RemoteRepositoryManager(graphDbUrl);
             repositoryManager.initialize();

--- a/src/main/java/nl/dtls/fairdatapoint/api/config/RestApiTestContext.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/config/RestApiTestContext.java
@@ -48,7 +48,6 @@ import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.sail.Sail;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.config.YamlMapFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/nl/dtls/fairdatapoint/api/config/RestApiTestContext.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/config/RestApiTestContext.java
@@ -28,7 +28,9 @@
 package nl.dtls.fairdatapoint.api.config;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import nl.dtl.fairmetadata4j.model.Agent;
@@ -46,6 +48,7 @@ import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.sail.Sail;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.YamlMapFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -58,8 +61,8 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 /**
- * Spring test context file. 
- * 
+ * Spring test context file.
+ *
  * @author Rajaram Kaliyaperumal <rr.kaliyaperumal@gmail.com>
  * @author Kees Burger <kees.burger@dtls.nl>
  * @since 2016-02-11
@@ -69,68 +72,75 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 @EnableAsync
 @Configuration
 @ComponentScan(basePackages = "nl.dtls.fairdatapoint.*")
-public class RestApiTestContext extends WebMvcConfigurerAdapter  {
-    
+public class RestApiTestContext extends WebMvcConfigurerAdapter {
+
     @Autowired
-    private List<AbstractMetadataMessageConverter<?>> metadataConverters;    
-    
+    private List<AbstractMetadataMessageConverter<?>> metadataConverters;
+
     private final ValueFactory valueFactory = SimpleValueFactory.getInstance();
-    
+
     @Override
-    public void configureMessageConverters(List<HttpMessageConverter<?>> 
-            converters) {
+    public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
         converters.addAll(metadataConverters);
     }
-    
+
     @Override
-    public void configureContentNegotiation(ContentNegotiationConfigurer 
-            configurer) {
-        for (AbstractMetadataMessageConverter<?> converter : 
-                metadataConverters) {
+    public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
+        
+        for (AbstractMetadataMessageConverter<?> converter : metadataConverters) {
             converter.configureContentNegotiation(configurer);
         }
     }
-    
+
     @Bean
     public Executor threadPoolTaskExecutor() {
         return Executors.newCachedThreadPool();
     }
-    
-    @Bean(name="repository", initMethod = "initialize",
-            destroyMethod = "shutDown")
-    public Repository repository(final Environment env)
-            throws RepositoryException, IOException, RDFParseException {
-        // For tets we use only in memory
+
+    @Bean(name = "repository", initMethod = "initialize", destroyMethod = "shutDown")
+    public Repository repository(final Environment env) throws RepositoryException, IOException
+            ,RDFParseException {
+        
+        // For tests we use only in memory
         Sail store = new MemoryStore();
         return new SailRepository(store);
     }
-    
+
     @Bean(name = "storeManager")
     @DependsOn({"repository"})
-    public StoreManager storeManager() throws RepositoryException,
-            StoreManagerException {
+    public StoreManager storeManager() throws RepositoryException, StoreManagerException {
         return new StoreManagerImpl();
     }
-        
+
     @Bean(name = "publisher")
     public Agent publisher() {
+        
         Agent publisher = new Agent();
         publisher.setUri(valueFactory.createIRI("https://www.dtls.nl"));
         publisher.setName(valueFactory.createLiteral("DTLS"));
         return publisher;
-    } 
-    
+    }
+
     @Bean(name = "language")
     public IRI language() {
-        IRI language = valueFactory.createIRI(
-                "http://id.loc.gov/vocabulary/iso639-1/en");
+        
+        IRI language = valueFactory.createIRI("http://id.loc.gov/vocabulary/iso639-1/en");
         return language;
     }
-    
+
     @Bean(name = "license")
     public IRI license() {
-        IRI license =  valueFactory.createIRI(
+        
+        IRI license = valueFactory.createIRI(
                 "http://rdflicense.appspot.com/rdflicense/cc-by-nc-nd3.0");
         return license;
-    } 
+    }
+
+    @Bean(name = "metadataMetrics")
+    public Map<String, String> metadataMetrics(Environment env) {
+        
+        Map<String, String> metadataMetrics = new HashMap();
+        metadataMetrics.put("https://purl.org/fair-metrics/FM_F1A", "http://example.com/f1a");
+        return metadataMetrics;
+    }
 }

--- a/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImpl.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImpl.java
@@ -107,15 +107,15 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
     @Autowired
     private FairMetaDataMetricsService fmMetricsService;
 
-    @Value("${metadataProperties.rootSpecs:nil}")
+    @Value("${metadataProperties.rootSpecs:}")
     private String fdpSpecs;
-    @Value("${metadataProperties.catalogSpecs:nil}")
+    @Value("${metadataProperties.catalogSpecs:}")
     private String catalogSpecs;
-    @Value("${metadataProperties.datasetSpecs:nil}")
+    @Value("${metadataProperties.datasetSpecs:}")
     private String datasetSpecs;
-    @Value("${metadataProperties.datarecordSpecs:nil}")
+    @Value("${metadataProperties.datarecordSpecs:}")
     private String datarecordSpecs;
-    @Value("${metadataProperties.distributionSpecs:nil}")
+    @Value("${metadataProperties.distributionSpecs:}")
     private String distributionSpecs;
     @Value("${metadataProperties.accessRightsDescription:This resource has no access restriction}")
     private String accessRightsDescription;
@@ -174,7 +174,7 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
     public void storeFDPMetaData(@Nonnull FDPMetadata metadata)
             throws FairMetadataServiceException, MetadataException {
         Preconditions.checkNotNull(metadata, "FDPMetadata must not be null.");
-        if (!fdpSpecs.isEmpty() && !fdpSpecs.contains("nil")) {
+        if (!fdpSpecs.isEmpty()) {
             metadata.setSpecification(VALUEFACTORY.createIRI(fdpSpecs));
         }
         storeMetadata(metadata);
@@ -195,8 +195,7 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
 //        Preconditions.checkState(isSubjectURIExist(metadata.getParentURI()),
 //                "The fdp URI doesn't exist in the repository. "
 //                + "Please try with valid fdp URI");        
-        if (!catalogSpecs.isEmpty()
-                && !catalogSpecs.contains("nil")) {
+        if (!catalogSpecs.isEmpty()) {
             metadata.setSpecification(VALUEFACTORY.createIRI(catalogSpecs));
         }
         if (doesParentResourceExists(metadata)) {
@@ -218,8 +217,7 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
         Preconditions.checkState(isSubjectURIExist(metadata.getParentURI()),
                 "The catalog URI doesn't exist in the repository. "
                 + "Please try with valid catalog URI");
-        if (!datasetSpecs.isEmpty()
-                && !datasetSpecs.contains("nil")) {
+        if (!datasetSpecs.isEmpty()) {
             metadata.setSpecification(VALUEFACTORY.createIRI(datasetSpecs));
         }
         if (doesParentResourceExists(metadata)) {
@@ -241,10 +239,8 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
         Preconditions.checkState(isSubjectURIExist(metadata.getParentURI()),
                 "The dataset URI doesn't exist in the repository. "
                 + "Please try with valid dataset URI");
-        if (!distributionSpecs.isEmpty()
-                && !distributionSpecs.contains("nil")) {
-            metadata.setSpecification(VALUEFACTORY.createIRI(
-                    distributionSpecs));
+        if (!distributionSpecs.isEmpty()) {
+            metadata.setSpecification(VALUEFACTORY.createIRI(distributionSpecs));
         }
         if (doesParentResourceExists(metadata)) {
             storeMetadata(metadata);
@@ -265,10 +261,8 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
         Preconditions.checkState(isSubjectURIExist(metadata.getParentURI()),
                 "The dataset URI doesn't exist in the repository. "
                 + "Please try with valid dataset URI");
-        if (!datarecordSpecs.isEmpty()
-                && !datarecordSpecs.contains("nil")) {
-            metadata.setSpecification(VALUEFACTORY.createIRI(
-                    datarecordSpecs));
+        if (!datarecordSpecs.isEmpty()) {
+            metadata.setSpecification(VALUEFACTORY.createIRI(datarecordSpecs));
         }
         if (doesParentResourceExists(metadata)) {
             storeMetadata(metadata);

--- a/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImpl.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImpl.java
@@ -72,6 +72,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Service;
 
@@ -106,20 +107,17 @@ public class FairMetaDataServiceImpl implements FairMetaDataService {
     @Autowired
     private FairMetaDataMetricsService fmMetricsService;
 
-    @org.springframework.beans.factory.annotation.Value("${metadataProperties.rootSpecs:nil}")
+    @Value("${metadataProperties.rootSpecs:nil}")
     private String fdpSpecs;
-    @org.springframework.beans.factory.annotation.Value("${metadataProperties.catalogSpecs:nil}")
+    @Value("${metadataProperties.catalogSpecs:nil}")
     private String catalogSpecs;
-    @org.springframework.beans.factory.annotation.Value("${metadataProperties.datasetSpecs:nil}")
+    @Value("${metadataProperties.datasetSpecs:nil}")
     private String datasetSpecs;
-    @org.springframework.beans.factory.annotation.Value(
-            "${metadataProperties.datarecordSpecs:nil}")
+    @Value("${metadataProperties.datarecordSpecs:nil}")
     private String datarecordSpecs;
-    @org.springframework.beans.factory.annotation.Value(
-            "${metadataProperties.distributionSpecs:nil}")
+    @Value("${metadataProperties.distributionSpecs:nil}")
     private String distributionSpecs;
-    @org.springframework.beans.factory.annotation.Value(
-            "${metadataProperties.accessRightsDescription:This resource has no access restriction}")
+    @Value("${metadataProperties.accessRightsDescription:This resource has no access restriction}")
     private String accessRightsDescription;
 
     @Override

--- a/src/main/resources/conf/fdpConfig.yml
+++ b/src/main/resources/conf/fdpConfig.yml
@@ -1,10 +1,18 @@
-# valid store type options { 1 = http SPARQLRepository, 2 = NativeStore, 3 = inMemoryStore}
+# valid store type options {1 = inMemoryStore, 2 = NativeStore, 3 = AllegroGraph, 4 = graphDB, 5 = blazegraph}
 store:
-    type: 3
-    url: http://136.243.4.200:8892/repositories/test
-    username: test
-    password: tester
-    dir: /tmp/fdp-store/
+    type: 5
+    agraph:
+        url: http://136.243.4.200:8892/repositories/test
+        username: test
+        password: tester
+    graphDb:
+        url: http://localhost:7200
+        repository: test
+    blazegraph:
+        url: http://localhost:8079/blazegraph
+        repository: fdp    
+    native:    
+        dir: /tmp/fdp-store/
 urlPath:
     root: /fdp
 metadataProperties:

--- a/src/main/resources/conf/fdpConfig.yml
+++ b/src/main/resources/conf/fdpConfig.yml
@@ -1,8 +1,8 @@
 # valid store type options {1 = inMemoryStore, 2 = NativeStore, 3 = AllegroGraph, 4 = graphDB, 5 = blazegraph}
 store:
-    type: 5
+    type: 3
     agraph:
-        url: http://136.243.4.200:8892/repositories/test
+        url: http://localhost:10035/repositories/fdp
         username: test
         password: tester
     graphDb:

--- a/src/main/resources/conf/fdpConfig.yml
+++ b/src/main/resources/conf/fdpConfig.yml
@@ -1,6 +1,6 @@
 # valid store type options {1 = inMemoryStore, 2 = NativeStore, 3 = AllegroGraph, 4 = graphDB, 5 = blazegraph}
 store:
-    type: 3
+    type: 1
     agraph:
         url: http://localhost:10035/repositories/fdp
         username: test

--- a/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataMetricsServiceImplTest.java
+++ b/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataMetricsServiceImplTest.java
@@ -30,6 +30,7 @@ package nl.dtls.fairdatapoint.service.impl;
 import java.util.List;
 import nl.dtl.fairmetadata4j.model.Metric;
 import nl.dtls.fairdatapoint.api.config.RestApiContext;
+import nl.dtls.fairdatapoint.api.config.RestApiTestContext;
 import nl.dtls.fairdatapoint.service.FairMetaDataMetricsService;
 import nl.dtls.fairdatapoint.utils.ExampleFilesUtils;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -52,7 +53,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
-@ContextConfiguration(classes = {RestApiContext.class})
+@ContextConfiguration(classes = {RestApiTestContext.class})
 public class FairMetaDataMetricsServiceImplTest {    
     
     @Autowired


### PR DESCRIPTION
I added configuration to use graphDB and blazegraph triple store. In the current implementation we support 3 external triple stores(Agraph, graphDB, blazegraph), we also provide options to user to use native and in-memory store. I also changed the context of this test class "FairMetaDataMetricsServiceImplTest". In the current implementation I use private fields in the context class to get the triple stores properties. We could also capture these properties in a separate object but it is up to discussion anyway.  