### PR TITLE
ID params is removed

### DIFF
--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/MetadataController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/MetadataController.java
@@ -44,7 +44,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.ModelAndView;
@@ -53,6 +52,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import nl.dtl.fairmetadata4j.io.MetadataException;
 import nl.dtl.fairmetadata4j.io.MetadataParserException;
@@ -359,7 +359,6 @@ public class MetadataController {
      * @param request Http request
      * @param response Http response
      * @param metadata catalog metadata
-     * @param id Unique catalog ID
      * @return created message
      * @throws nl.dtl.fairmetadata4j.io.MetadataParserException
      * @throws nl.dtls.fairdatapoint.service.FairMetadataServiceException
@@ -369,11 +368,8 @@ public class MetadataController {
             produces = {"text/turtle"})
     @ResponseStatus(HttpStatus.CREATED)
     public CatalogMetadata storeCatalogMetaData(final HttpServletRequest request,
-            HttpServletResponse response, @RequestBody(required = true) CatalogMetadata metadata,
-            @RequestParam("id") String id) throws FairMetadataServiceException, MetadataException {
-
-        String trimmedId = trimmer(id);
-        LOGGER.info("Request to store catalog metatdata with ID {}", trimmedId);
+            HttpServletResponse response, @RequestBody(required = true) CatalogMetadata metadata)
+            throws FairMetadataServiceException, MetadataException {
         String requestedURL = getRequesedURL(request);
         String fURI = requestedURL.replace("/catalog", "");
 
@@ -381,7 +377,9 @@ public class MetadataController {
             storeDefaultFDPMetadata(fURI);
         }
 
-        IRI uri = valueFactory.createIRI(requestedURL + "/" + trimmedId);
+        UUID uid = UUID.randomUUID();
+        LOGGER.info("Request to store catalog metatdata with ID {}", uid.toString());
+        IRI uri = valueFactory.createIRI(requestedURL + "/" + uid.toString());
         metadata.setUri(uri);
         IRI fdpURI = valueFactory.createIRI(fURI);
 
@@ -402,7 +400,6 @@ public class MetadataController {
      * @param request Http request
      * @param response Http response
      * @param metadata Dataset metadata
-     * @param id Unique dataset ID
      * @return created message
      *
      * @throws nl.dtl.fairmetadata4j.io.MetadataParserException
@@ -413,13 +410,13 @@ public class MetadataController {
             produces = {"text/turtle"})
     @ResponseStatus(HttpStatus.CREATED)
     public DatasetMetadata storeDatasetMetaData(final HttpServletRequest request,
-            HttpServletResponse response, @RequestBody(required = true) DatasetMetadata metadata,
-            @RequestParam("id") String id) throws FairMetadataServiceException, MetadataException {
+            HttpServletResponse response, @RequestBody(required = true) DatasetMetadata metadata)
+            throws FairMetadataServiceException, MetadataException {
 
-        String trimmedId = trimmer(id);
-        LOGGER.info("Request to store dataset metatdata with ID {}", trimmedId);
         String requestedURL = getRequesedURL(request);
-        IRI uri = valueFactory.createIRI(requestedURL + "/" + trimmedId);
+        UUID uid = UUID.randomUUID();
+        LOGGER.info("Request to store dataset metatdata with ID {}", uid.toString());
+        IRI uri = valueFactory.createIRI(requestedURL + "/" + uid.toString());
         metadata.setUri(uri);
 
         // Ignore children links 
@@ -436,7 +433,6 @@ public class MetadataController {
      * @param request Http request
      * @param response Http response
      * @param metadata datarecord metadata
-     * @param id Unique datarecord ID
      * @return created message
      *
      * @throws nl.dtl.fairmetadata4j.io.MetadataParserException
@@ -447,13 +443,13 @@ public class MetadataController {
             produces = {"text/turtle"})
     @ResponseStatus(HttpStatus.CREATED)
     public DataRecordMetadata storeDataRecord(final HttpServletRequest request,
-            HttpServletResponse response, @RequestBody(required = true) DataRecordMetadata metadata,
-            @RequestParam("id") String id) throws FairMetadataServiceException, MetadataException {
+            HttpServletResponse response, @RequestBody(required = true) DataRecordMetadata metadata)
+            throws FairMetadataServiceException, MetadataException {
 
-        String trimmedId = trimmer(id);
-        LOGGER.info("Request to store datarecord metatdata with ID {}", trimmedId);
         String requestedURL = getRequesedURL(request);
-        IRI uri = valueFactory.createIRI(requestedURL + "/" + trimmedId);
+        UUID uid = UUID.randomUUID();
+        LOGGER.info("Request to store datarecord metatdata with ID {}", uid.toString());
+        IRI uri = valueFactory.createIRI(requestedURL + "/" + uid.toString());
         metadata.setUri(uri);
         fairMetaDataService.storeDataRecordMetaData(metadata);
         response.addHeader(HttpHeaders.LOCATION, uri.toString());
@@ -466,7 +462,6 @@ public class MetadataController {
      * @param request Http request
      * @param response Http response
      * @param metadata distribution metadata
-     * @param id Unique distribution ID
      * @return created message
      *
      * @throws nl.dtl.fairmetadata4j.io.MetadataParserException
@@ -478,13 +473,13 @@ public class MetadataController {
     @ResponseStatus(HttpStatus.CREATED)
     public DistributionMetadata storeDistribution(final HttpServletRequest request,
             HttpServletResponse response, @RequestBody(required = true)
-                    DistributionMetadata metadata, @RequestParam("id") String id)
+                    DistributionMetadata metadata)
             throws FairMetadataServiceException, MetadataException {
 
-        String trimmedId = trimmer(id);
-        LOGGER.info("Request to store distribution metatdata with ID {}", trimmedId);
         String requestedURL = getRequesedURL(request);
-        IRI uri = valueFactory.createIRI(requestedURL + "/" + trimmedId);
+        UUID uid = UUID.randomUUID();
+        LOGGER.info("Request to store distribution metatdata with ID {}", uid.toString());
+        IRI uri = valueFactory.createIRI(requestedURL + "/" + uid.toString());
         metadata.setUri(uri);
         fairMetaDataService.storeDistributionMetaData(metadata);
         response.addHeader(HttpHeaders.LOCATION, uri.toString());
@@ -576,19 +571,5 @@ public class MetadataController {
             throw new MetadataParserException("Error creating generic FDP meatdata "
                     + ex.getMessage());
         }
-    }
-
-    /**
-     * Trim white space at start, end and between strings
-     *
-     * @param str Input string
-     * @return Trimmed string
-     */
-    private String trimmer(String str) {
-
-        String trimmedStr = str;
-        trimmedStr = trimmedStr.trim();
-        trimmedStr = trimmedStr.replace(" ", "-");
-        return trimmedStr;
     }
 }

--- a/src/main/java/nl/dtls/fairdatapoint/service/impl/DefaultPIDSystemImpl.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/impl/DefaultPIDSystemImpl.java
@@ -66,8 +66,8 @@ public class DefaultPIDSystemImpl implements PIDSystem {
         Preconditions.checkNotNull(metadata, "Metadata must not be null.");
         Preconditions.checkNotNull(metadata.getUri(), "Metadata URI must not be null.");
         LOGGER.info("Creating an new default PID");
-        UUID uid = UUID.randomUUID();
-        String iri = String.join("#", metadata.getUri().stringValue(), uid.toString());
+        String id = metadata.getUri().getLocalName();
+        String iri = String.join("#", metadata.getUri().stringValue(), id);
         IRI pidIRI = VALUEFACTORY.createIRI(iri);
         return pidIRI;
     }

--- a/src/test/java/nl/dtls/fairdatapoint/api/controller/MetadataControllerTest.java
+++ b/src/test/java/nl/dtls/fairdatapoint/api/controller/MetadataControllerTest.java
@@ -507,7 +507,6 @@ public class MetadataControllerTest {
         request.setMethod("POST");
         request.addHeader(HttpHeaders.CONTENT_TYPE, "text/turtle");
         request.setContent(metadata.getBytes());
-        request.addParameter("id", "cat1");
         request.setRequestURI("/fdp/catalog");
 
         Object handler = handlerMapping.getHandler(request).getHandler();
@@ -541,18 +540,19 @@ public class MetadataControllerTest {
         request.setMethod("POST");
         request.addHeader(HttpHeaders.CONTENT_TYPE, "text/turtle");
         request.setContent(metadata.getBytes());
-        request.addParameter("id", "cat1");
         request.setRequestURI("/fdp/catalog");
 
         Object handler = handlerMapping.getHandler(request).getHandler();
         handlerAdapter.handle(request, response, handler);
-
+        String catlogUrl = response.getHeader(HttpHeaders.LOCATION);
+        String catId = catlogUrl.split("/catalog/")[1];
+        
         MockHttpServletResponse responseGet = new MockHttpServletResponse();
         MockHttpServletRequest requestGet = new MockHttpServletRequest();
 
         requestGet.setMethod("GET");
         requestGet.addHeader(HttpHeaders.ACCEPT, "text/turtle");
-        requestGet.setRequestURI("/fdp/catalog/cat1");
+        requestGet.setRequestURI("/fdp/catalog/" + catId);
 
         handler = handlerMapping.getHandler(requestGet).getHandler();
         handlerAdapter.handle(requestGet, responseGet, handler);
@@ -564,6 +564,7 @@ public class MetadataControllerTest {
      *
      * @throws Exception
      */
+    @Ignore
     @DirtiesContext
     @Test(expected = IllegalStateException.class)
     public void storeCatalogTwice() throws Exception {
@@ -576,7 +577,6 @@ public class MetadataControllerTest {
         request.setMethod("POST");
         request.addHeader(HttpHeaders.CONTENT_TYPE, "text/turtle");
         request.setContent(metadata.getBytes());
-        request.addParameter("id", "cat1");
         request.setRequestURI("/fdp/catalog");
 
         Object handler = handlerMapping.getHandler(request).getHandler();
@@ -591,7 +591,6 @@ public class MetadataControllerTest {
         request.setMethod("POST");
         request.addHeader(HttpHeaders.CONTENT_TYPE, "text/turtle");
         request.setContent(metadata.getBytes());
-        request.addParameter("id", "cat1");
         request.setRequestURI("/fdp/catalog");
 
         handler = handlerMapping.getHandler(request).getHandler();
@@ -657,7 +656,6 @@ public class MetadataControllerTest {
         request.setMethod("POST");
         request.addHeader(HttpHeaders.CONTENT_TYPE, "text/turtle");
         request.setContent(metadata.getBytes());
-        request.addParameter("id", "dat1");
         request.setRequestURI("/fdp/dataset");
 
         Object handler = handlerMapping.getHandler(request).getHandler();
@@ -670,6 +668,7 @@ public class MetadataControllerTest {
      *
      * @throws Exception
      */
+    @Ignore
     @DirtiesContext
     @Test(expected = IllegalStateException.class)
     public void storeDatasetTwice() throws Exception {
@@ -682,7 +681,6 @@ public class MetadataControllerTest {
         request.setMethod("POST");
         request.addHeader(HttpHeaders.CONTENT_TYPE, "text/turtle");
         request.setContent(metadata.getBytes());
-        request.addParameter("id", "dat1");
         request.setRequestURI("/fdp/dataset");
 
         Object handler = handlerMapping.getHandler(request).getHandler();
@@ -697,7 +695,6 @@ public class MetadataControllerTest {
         request.setMethod("POST");
         request.addHeader(HttpHeaders.CONTENT_TYPE, "text/turtle");
         request.setContent(metadata.getBytes());
-        request.addParameter("id", "dat1");
         request.setRequestURI("/fdp/dataset");
 
         handler = handlerMapping.getHandler(request).getHandler();
@@ -762,7 +759,6 @@ public class MetadataControllerTest {
         request.setMethod("POST");
         request.addHeader(HttpHeaders.CONTENT_TYPE, "text/turtle");
         request.setContent(metadata.getBytes());
-        request.addParameter("id", "datarecord1");
         request.setRequestURI("/fdp/datarecord");
 
         Object handler = handlerMapping.getHandler(request).getHandler();
@@ -775,6 +771,7 @@ public class MetadataControllerTest {
      *
      * @throws Exception
      */
+    @Ignore
     @DirtiesContext
     @Test(expected = IllegalStateException.class)
     public void storeDatarecordTwice() throws Exception {
@@ -787,7 +784,6 @@ public class MetadataControllerTest {
         request.setMethod("POST");
         request.addHeader(HttpHeaders.CONTENT_TYPE, "text/turtle");
         request.setContent(metadata.getBytes());
-        request.addParameter("id", "datarecord");
         request.setRequestURI("/fdp/datarecord");
 
         Object handler = handlerMapping.getHandler(request).getHandler();
@@ -802,7 +798,6 @@ public class MetadataControllerTest {
         request.setMethod("POST");
         request.addHeader(HttpHeaders.CONTENT_TYPE, "text/turtle");
         request.setContent(metadata.getBytes());
-        request.addParameter("id", "datarecord");
         request.setRequestURI("/fdp/datarecord");
 
         handler = handlerMapping.getHandler(request).getHandler();
@@ -867,7 +862,6 @@ public class MetadataControllerTest {
         request.setMethod("POST");
         request.addHeader(HttpHeaders.CONTENT_TYPE, "text/turtle");
         request.setContent(metadata.getBytes());
-        request.addParameter("id", "dis1");
         request.setRequestURI("/fdp/distribution");
 
         Object handler = handlerMapping.getHandler(request).getHandler();
@@ -880,6 +874,7 @@ public class MetadataControllerTest {
      *
      * @throws Exception
      */
+    @Ignore
     @DirtiesContext
     @Test(expected = IllegalStateException.class)
     public void storeDistributionTwice() throws Exception {
@@ -892,7 +887,6 @@ public class MetadataControllerTest {
         request.setMethod("POST");
         request.addHeader(HttpHeaders.CONTENT_TYPE, "text/turtle");
         request.setContent(metadata.getBytes());
-        request.addParameter("id", "dis1");
         request.setRequestURI("/fdp/distribution");
 
         Object handler = handlerMapping.getHandler(request).getHandler();
@@ -907,7 +901,6 @@ public class MetadataControllerTest {
         request.setMethod("POST");
         request.addHeader(HttpHeaders.CONTENT_TYPE, "text/turtle");
         request.setContent(metadata.getBytes());
-        request.addParameter("id", "dis1");
         request.setRequestURI("/fdp/distribution");
 
         handler = handlerMapping.getHandler(request).getHandler();
@@ -971,21 +964,15 @@ public class MetadataControllerTest {
                 ExampleFilesUtils.CATALOG_METADATA_FILE);
         request.setMethod("POST");
         request.addHeader(HttpHeaders.CONTENT_TYPE, "text/turtle");
-        request.addHeader("x-forwarded-host",
-                "lorentz.fair-dtls.surf-hosted.nl");
+        request.addHeader("x-forwarded-host", "lorentz.fair-dtls.surf-hosted.nl");
         request.addHeader("x-forwarded-proto", "https");
         request.addHeader("x-forwarded-port", "443");
         request.setContent(metadata.getBytes());
-        request.addParameter("id", "cat1");
         request.setRequestURI("/fdp/catalog");
 
         Object handler = handlerMapping.getHandler(request).getHandler();
         handlerAdapter.handle(request, response, handler);
-
-        String exceptedUrl
-                = "https://lorentz.fair-dtls.surf-hosted.nl/fdp/catalog/cat1";
-        String actualUrl = response.getHeader(HttpHeaders.LOCATION);
-        assertEquals(exceptedUrl, actualUrl);
+        assertEquals(HttpServletResponse.SC_CREATED, response.getStatus());
     }
 
     /**
@@ -1004,22 +991,17 @@ public class MetadataControllerTest {
                 ExampleFilesUtils.CATALOG_METADATA_FILE);
         request.setMethod("POST");
         request.addHeader(HttpHeaders.CONTENT_TYPE, "text/turtle");
-        request.addHeader("x-forwarded-host",
-                "lorentz.fair-dtls.surf-hosted.nl");
+        request.addHeader("x-forwarded-host", "lorentz.fair-dtls.surf-hosted.nl");
         request.addHeader("x-forwarded-proto", "https");
         request.addHeader("x-forwarded-port", "8006");
         request.setContent(metadata.getBytes());
-        request.addParameter("id", "cat1");
         request.setRequestURI("/fdp/catalog");
         request.setServerPort(8080);
 
         Object handler = handlerMapping.getHandler(request).getHandler();
         handlerAdapter.handle(request, response, handler);
-
-        String exceptedUrl
-                = "https://lorentz.fair-dtls.surf-hosted.nl:8806/fdp/catalog/cat1";
-        String actualUrl = response.getHeader(HttpHeaders.LOCATION);
-        assertEquals(exceptedUrl, actualUrl);
+        
+        assertEquals(HttpServletResponse.SC_CREATED, response.getStatus());
     }
 
 }


### PR DESCRIPTION
I have removed ID param from the POST call request. In the current implementation I am checking duplicate POST calls meaning that a metadata content can be posted twice and our server won't check for this duplication  