### PR TITLE
Updated test in the service layer to better handle race conditions in timestamps

### DIFF
--- a/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImplTest.java
+++ b/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImplTest.java
@@ -933,8 +933,8 @@ public class FairMetaDataServiceImplTest {
                     VALUEFACTORY.createIRI(ExampleFilesUtils.DATASET_URI));
             ZonedDateTime updatedModified = ZonedDateTime.parse(
                     updated.getModified().stringValue());
-            assertTrue("Distribution is modified before the dataset is modified",
-                    distributionModified.isBefore(updatedModified));
+            assertFalse("Distribution is modified before the dataset is modified",
+                    distributionModified.isAfter(updatedModified));
         }
         // compare catalog timestamp with distribution timestamp
         {
@@ -942,8 +942,8 @@ public class FairMetaDataServiceImplTest {
                     VALUEFACTORY.createIRI(ExampleFilesUtils.CATALOG_URI));
             ZonedDateTime updatedModified = ZonedDateTime.parse(
                     updated.getModified().stringValue());
-            assertTrue("Distribution is modified before the catalog is modified",
-                    distributionModified.isBefore(updatedModified));
+            assertFalse("Distribution is modified before the catalog is modified",
+                    distributionModified.isAfter(updatedModified));
         }
         // compare repository timestamp with distribution timestamp
         {
@@ -951,8 +951,8 @@ public class FairMetaDataServiceImplTest {
                     VALUEFACTORY.createIRI(ExampleFilesUtils.FDP_URI));
             ZonedDateTime updatedModified = ZonedDateTime.parse(
                     updated.getModified().stringValue());
-            assertTrue("Distribution is modified before the repository is modified",
-                    distributionModified.isBefore(updatedModified));
+            assertFalse("Distribution is modified before the repository is modified",
+                    distributionModified.isAfter(updatedModified));
         }
     }
 

--- a/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImplTest.java
+++ b/src/test/java/nl/dtls/fairdatapoint/service/impl/FairMetaDataServiceImplTest.java
@@ -933,7 +933,7 @@ public class FairMetaDataServiceImplTest {
                     VALUEFACTORY.createIRI(ExampleFilesUtils.DATASET_URI));
             ZonedDateTime updatedModified = ZonedDateTime.parse(
                     updated.getModified().stringValue());
-            assertFalse("Distribution is modified before the dataset is modified",
+            assertFalse("Distribution is modified after the dataset is modified",
                     distributionModified.isAfter(updatedModified));
         }
         // compare catalog timestamp with distribution timestamp
@@ -942,7 +942,7 @@ public class FairMetaDataServiceImplTest {
                     VALUEFACTORY.createIRI(ExampleFilesUtils.CATALOG_URI));
             ZonedDateTime updatedModified = ZonedDateTime.parse(
                     updated.getModified().stringValue());
-            assertFalse("Distribution is modified before the catalog is modified",
+            assertFalse("Distribution is modified after the catalog is modified",
                     distributionModified.isAfter(updatedModified));
         }
         // compare repository timestamp with distribution timestamp
@@ -951,7 +951,7 @@ public class FairMetaDataServiceImplTest {
                     VALUEFACTORY.createIRI(ExampleFilesUtils.FDP_URI));
             ZonedDateTime updatedModified = ZonedDateTime.parse(
                     updated.getModified().stringValue());
-            assertFalse("Distribution is modified before the repository is modified",
+            assertFalse("Distribution is modified after the repository is modified",
                     distributionModified.isAfter(updatedModified));
         }
     }


### PR DESCRIPTION
The old situation required the child timestamp to be before parent timestamp, but it should have been before-or-equal. It is now changed to after, which encompasses before and equal.